### PR TITLE
feature #698 - enhance sechub-api.sh script

### DIFF
--- a/sechub-developertools/scripts/sechub-api.sh
+++ b/sechub-developertools/scripts/sechub-api.sh
@@ -15,7 +15,7 @@ function usage {
   cat - <<EOF
 Usage: `basename $0` [-p] [-y] [-s <sechub server url> [-u <sechub user>] [-a <sechub api token>] action [<action's parameters>]
 
-Shell front end to selected SecHub API calls.
+Shell front end to selected SecHub API calls (https://daimler.github.io/sechub/latest/sechub-restapi.html).
 Output will be beautified/colorized by piping json output through jq command (https://github.com/stedolan/jq)
 unless you specify -p or -plain option. Option -y or -yes skips confirmation dialog when deleting items.
 


### PR DESCRIPTION
Make `sechub-api.sh`'s coverage of SecHub REST api more complete

-   alive check
-   read and write mock data (for mocked products; needed for automated project creations on playground/test environments)
-   delete user, delete project (with confirmation)
-   grant+revoke superadmin role
-   change owner of project
-   set project metadata
-   product executors (list, create, update, delete)
-   execution profiles (create, update, delete)

Improve messages when a required parameter is missing.

closes #698 