### PR TITLE
Upgrade SpringBoot to 2.6

### DIFF
--- a/build-java.gradle
+++ b/build-java.gradle
@@ -41,7 +41,7 @@ subprojects{
     
     dependencies {
         // https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine
-        testImplementation group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.7.1'
+        testImplementation group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.8.2'
         testImplementation 'org.junit.platform:junit-platform-launcher' // fix eclipse 4.16 launching problems , see https://github.com/spring-projects/sts4/issues/431 
     }
     

--- a/build-spring.gradle
+++ b/build-spring.gradle
@@ -11,7 +11,7 @@ subprojects {
          }
     }
     
-    ext['junit-jupiter.version'] = '5.6.0'
+    ext['junit-jupiter.version'] = '5.8.2'
 
     logger.info("found spring boot relevant project:$project")
     

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'org.asciidoctor.jvm.pdf' version '3.3.2'
     id 'org.openapi.generator' version '5.2.0'
-    id 'org.springframework.boot' version '2.5.8' apply false
+    id 'org.springframework.boot' version '2.6.2' apply false
 }
 /* check buildsystem */
 def githubActor = System.getenv('GITHUB_ACTOR')

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -13,7 +13,7 @@ ext {
 
    libraryVersion= [
       // openapi3-generator, releases see https://github.com/ePages-de/restdocs-api-spec/releases
-      restDocsApiSpec: "0.11.4"
+      restDocsApiSpec: "0.15.2"
    ]
 
    library = [
@@ -22,8 +22,8 @@ ext {
         /* autark JUnit parts, with same versions like current used spring boot version */
         // https://mvnrepository.com/artifact/junit/junit
         junit: "junit:junit:4.13.2",
-        junit5_impl: 'org.junit.jupiter:junit-jupiter-api:5.7.2',
-        junit5_runtime: 'org.junit.jupiter:junit-jupiter-engine:5.7.2',
+        junit5_impl: 'org.junit.jupiter:junit-jupiter-api:5.8.2',
+        junit5_runtime: 'org.junit.jupiter:junit-jupiter-engine:5.8.2',
         
 //      Adopting existing Junit4 to Junit5 tests: 
 //      currently we keep our exting Junit4 tests and do NOT transform them. 
@@ -31,10 +31,10 @@ ext {
 //      https://github.com/junit-team/junit5-samples/tree/master/junit5-migration-gradle        
         
         // https://mvnrepository.com/artifact/org.mockito/mockito-core
-        mockito: "org.mockito:mockito-core:3.9.0", //IMPORTANT: keep this at same level as used in Spring BOOT version
+        mockito: "org.mockito:mockito-core:4.0.0", //IMPORTANT: keep this at same level as used in Spring BOOT version
         
         // https://mvnrepository.com/artifact/org.mockito/mockito-inline
-        mockito_inline: "org.mockito:mockito-inline:3.9.0",
+        mockito_inline: "org.mockito:mockito-inline:4.0.0",
         
 
         // https://mvnrepository.com/artifact/org.hamcrest/hamcrest-library
@@ -69,11 +69,11 @@ ext {
          database_postgres:                     "org.postgresql:postgresql:42.3.1",
 
          /* jackson libraries - please keep in sync with used ones by spring boot!*/
-         jackson_JDK8:                          "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.3",
+         jackson_JDK8:                          "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.1",
          // https://mvnrepository.com/artifact/com.fasterxml.jackson.jr/jackson-jr-all
-         jackson_jr_all:                        "com.fasterxml.jackson.jr:jackson-jr-all:2.12.6",
-         jackson_core:                          "com.fasterxml.jackson.core:jackson-core:2.12.6",
-         jackson_databind:                      "com.fasterxml.jackson.core:jackson-databind:2.12.6",
+         jackson_jr_all:                        "com.fasterxml.jackson.jr:jackson-jr-all:2.13.1",
+         jackson_core:                          "com.fasterxml.jackson.core:jackson-core:2.13.1",
+         jackson_databind:                      "com.fasterxml.jackson.core:jackson-databind:2.13.1",
 
          /* apache commons */
          apache_httpcomponents_core:            "org.apache.httpcomponents:httpcore:4.4.15",
@@ -86,12 +86,12 @@ ext {
 
          openjson:                              "com.github.openjson:openjson:1.0.12",
 
-         flyway:                                "org.flywaydb:flyway-core:8.2.3",
+         flyway:                                "org.flywaydb:flyway-core:8.0.5",
 
          /* logback */
          // https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
          logback_classic:                       "ch.qos.logback:logback-classic:1.2.9",
-         logstashLogbackEncoder        :        "net.logstash.logback:logstash-logback-encoder:6.6",
+         logstashLogbackEncoder        :        "net.logstash.logback:logstash-logback-encoder:7.0.1",
 
          // JDK 10 build problems handling
          // https://stackoverflow.com/questions/43574426/how-to-resolve-java-langnoclassdeffounderror-javax-xml-bind-jaxbexception-in-j
@@ -114,7 +114,9 @@ ext {
          
          /* jsoup: Java HTML Parser - see: https://github.com/jhy/jsoup */
          jsoup:									"org.jsoup:jsoup:1.14.3",
-
+         
+         /* dom4j: https://mvnrepository.com/artifact/org.dom4j/dom4j/2.1.3 */
+		 dom4j:									"org.dom4j:dom4j:2.1.3",
    ]
 
 }

--- a/sechub-administration/build.gradle
+++ b/sechub-administration/build.gradle
@@ -6,11 +6,10 @@
  * ============================================================================
  */
 dependencies {
+    implementation project(':sechub-shared-kernel')
+    implementation library.springboot_starter_thymeleaf
 
-    compile project(':sechub-shared-kernel')
-    compile library.springboot_starter_thymeleaf
-
-    testCompile project(':sechub-testframework')
+    testImplementation project(':sechub-testframework')
 
 }
 

--- a/sechub-analyzer-cli/build.gradle
+++ b/sechub-analyzer-cli/build.gradle
@@ -6,16 +6,16 @@
  * ============================================================================
  */
 dependencies {
-	compile library.slf4j
-	compile library.logback_classic
-	compile library.apache_commons_cli
-	compile library.jackson_jr_all
-	compile library.google_re2j
+	implementation library.slf4j
+	implementation library.logback_classic
+	implementation library.apache_commons_cli
+	implementation library.jackson_jr_all
+	implementation library.google_re2j
 	
-	testCompile library.junit
-	testCompile library.mockito
-	testCompile library.mockito_inline
-    testCompile library.hamcrest
+	testImplementation library.junit
+	testImplementation library.mockito
+	testImplementation library.mockito_inline
+    testImplementation library.hamcrest
 }
 
 task buildAnalyzerCLI(type: Jar) {

--- a/sechub-authorization/build.gradle
+++ b/sechub-authorization/build.gradle
@@ -7,7 +7,7 @@
  */
 dependencies {
 
-    compile project(':sechub-shared-kernel')
-    testCompile project(':sechub-testframework')
+    implementation project(':sechub-shared-kernel')
+    testImplementation project(':sechub-testframework')
 
 }

--- a/sechub-sereco/build.gradle
+++ b/sechub-sereco/build.gradle
@@ -8,7 +8,11 @@
  
 dependencies {
 	implementation library.jsoup
-	implementation library.dom4j
+	implementation('org.dom4j:dom4j:2.1.3') {
+		exclude group: 'xpp3', module: 'xpp3'
+		exclude group: 'pull-parser', module: 'pull-parser'
+	}
+
 	    
     implementation project(':sechub-shared-kernel')
     implementation project(':sechub-sarif')

--- a/sechub-sereco/build.gradle
+++ b/sechub-sereco/build.gradle
@@ -7,12 +7,13 @@
  */
  
 dependencies {
-	compile library.jsoup
+	implementation library.jsoup
+	implementation library.dom4j
 	    
-    compile project(':sechub-shared-kernel')
-    compile project(':sechub-sarif')
+    implementation project(':sechub-shared-kernel')
+    implementation project(':sechub-sarif')
 
-    compile project(':sechub-shared-kernel')
+    implementation project(':sechub-shared-kernel')
     
-    testCompile project(':sechub-testframework')
+    testImplementation project(':sechub-testframework')
 }

--- a/sechub-sereco/build.gradle
+++ b/sechub-sereco/build.gradle
@@ -8,7 +8,7 @@
  
 dependencies {
 	implementation library.jsoup
-	implementation('org.dom4j:dom4j:2.1.3') {
+	implementation(library.dom4j) {
 		exclude group: 'xpp3', module: 'xpp3'
 		exclude group: 'pull-parser', module: 'pull-parser'
 	}

--- a/sechub-server/src/main/resources/application.yml
+++ b/sechub-server/src/main/resources/application.yml
@@ -44,6 +44,8 @@ spring:
   main:
     # see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
     allow-bean-definition-overriding: true
+    # see https://stackoverflow.com/questions/70036903/spring-boot-application-fails-to-start-after-upgrading-to-2-6-0-due-to-circular
+    allow-circular-references: true
   servlet: 
     # MultiPart file-size limits,
     # https://spring.io/guides/gs/uploading-files/

--- a/sechub-storage-sharedvolume-spring/build.gradle
+++ b/sechub-storage-sharedvolume-spring/build.gradle
@@ -7,7 +7,7 @@
  * ============================================================================
  */
 dependencies {
-    compile library.slf4j
-    compile project(':sechub-storage-core')
-
+    implementation library.slf4j
+    implementation project(':sechub-storage-core')
+	testImplementation library.mockito_inline
 }


### PR DESCRIPTION
- upgrade SpringBoot to 2.6
- upgrade Restdoc
- add Dom4J dependency, because it is not a Hibernate dependency anymore
- rewrite build.gradle of sechub-sereco and
sechub-storage-sharedvolume-spring to new Gradle format
- added mockito inline to sechub-storage-sharedvolume-spring
- downgrade flyway from 8.2.3 to 8.0.5 to be at the same level as SpringBoot

closes: #691