### PR TITLE
Client: improve error message when api token is wrong #281

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
@@ -50,7 +50,7 @@ func handleHTTPRequestAndResponse(context *Context, request *http.Request) *http
 	sechubUtil.HandleHTTPError(err, ExitCodeHTTPError) // Handle networking errors etc. (exit)
 
 	// Resilience handling
-	if response.StatusCode >= 400 { // StatusCode is in 4xx or 5xx
+	if response.StatusCode > 403 { // StatusCode is in 4xx(400-403 are unrecoverable) or 5xx
 		sechubUtil.LogWarning(
 			fmt.Sprintf("Received unexpected Status Code %d (%s) from server. Retrying in %d seconds...",
 				response.StatusCode, response.Status, context.config.waitSeconds))

--- a/sechub-cli/src/mercedes-benz.com/sechub/util/errorhandler.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/util/errorhandler.go
@@ -28,8 +28,12 @@ func HandleHTTPError(err error, exitCode int) {
 // HandleHTTPResponse - handler method for http response. when not 200 an error log entry will be created and sechub client does exit
 func HandleHTTPResponse(response *http.Response, exitCode int) {
 	if response.StatusCode >= 400 { // StatusCode is 4xx or 5xx
-		b, _ := ioutil.ReadAll(response.Body)
-		LogError(fmt.Sprintf("The HTTP request failed with status code '%s'\nbody=%s\n", response.Status, string(b)))
+		bodytext, _ := ioutil.ReadAll(response.Body)
+		LogError(fmt.Sprintf("The SecHub server responded with HTTP status code '%s'\nbody=%s\n", response.Status, string(bodytext)))
+		switch response.StatusCode {
+		case 401:
+			fmt.Println("Hint: Unauthorized - Please check if your SecHub credentials (userID and API-token) are valid.")
+		}
 		os.Exit(exitCode)
 	}
 }

--- a/sechub-cli/src/mercedes-benz.com/sechub/util/errorhandler.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/util/errorhandler.go
@@ -29,7 +29,7 @@ func HandleHTTPError(err error, exitCode int) {
 func HandleHTTPResponse(response *http.Response, exitCode int) {
 	if response.StatusCode >= 400 { // StatusCode is 4xx or 5xx
 		bodytext, _ := ioutil.ReadAll(response.Body)
-		LogError(fmt.Sprintf("The SecHub server responded with HTTP status code '%s'\nbody=%s\n", response.Status, string(bodytext)))
+		LogError(fmt.Sprintf("The SecHub server responded with HTTP status code '%s'\nbody=%s", response.Status, string(bodytext)))
 		switch response.StatusCode {
 		case 401:
 			fmt.Println("Hint: Unauthorized - Please check if your SecHub credentials (userID and API-token) are valid.")


### PR DESCRIPTION
hint added when 401 server response
- also wording improved
- retry only for > HTTP 403

closes #281 