### PR TITLE
Feature 290 client reduce json payload

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/controller.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/controller.go
@@ -29,12 +29,15 @@ func Execute() {
 	switch context.config.action {
 	case scanAction:
 		prepareCreateApproveJob(context)
-		waitForSecHubJobDoneAndFailOnTrafficLight(context)
+		status := waitForSecHubJobDone(context)
+		downloadSechubReport(context)
+		printSecHubJobSummaryAndFailOnTrafficLight(context, status)
 	case scanAsynchronAction:
 		prepareCreateApproveJob(context)
 		fmt.Println(context.config.secHubJobUUID)
 	case getStatusAction:
-		fmt.Println(getSecHubJobState(context, true, false, false))
+		_, jsonData := getSecHubJobStatus(context)
+		fmt.Println(jsonData)
 	case getReportAction:
 		downloadSechubReport(context)
 	case getFalsePositivesAction:

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
@@ -40,88 +40,55 @@ func approveSecHubJob(context *Context) {
 	sechubUtil.HandleError(err, ExitCodeFailed)
 }
 
-func waitForSecHubJobDoneAndFailOnTrafficLight(context *Context) string {
-	return getSecHubJobState(context, false, true, true)
-}
-
-func getSecHubJobState(context *Context, checkOnlyOnce bool, checkTrafficLight bool, downloadReport bool) string {
-	//    {
-	//    "jobUUID": "e21b13fc-591e-4abd-b119-755d473c5625",
-	//    "owner": "developer",
-	//    "created": "2018-03-06T12:59:59.691",
-	//    "started": "2018-03-06T13:00:00.007",
-	//    "ended": "2018-03-06T13:00:04.562",
-	//    "state": "ENDED",
-	//    "result": "OK",
-	//    "trafficLight": "GREEN"
-	//    }
-
-	//	{
-	//    "jobUUID": "a52e0695-5789-4902-9643-72d2ce138942",
-	//    "owner": "developer",
-	//    "created": "2018-03-08T23:08:54.014",
-	//    "started": "2018-03-08T23:08:55.013",
-	//    "ended": "2018-03-08T23:08:57.324",
-	//    "state": "ENDED",
-	//    "result": "FAILED",
-	//    "trafficLight": ""
-	//}
-
-	done := false
-	var status jobStatusResult
-
+func waitForSecHubJobDone(context *Context) (status jobStatusResult) {
 	newLine := true
 	cursor := 0
 
-	if checkOnlyOnce {
-		done = true
-	} else {
-		sechubUtil.Log(fmt.Sprintf("Waiting for job %s to be done", context.config.secHubJobUUID), context.config.quiet)
-	}
+	sechubUtil.Log(fmt.Sprintf("Waiting for job %s to be done", context.config.secHubJobUUID), context.config.quiet)
 
 	for {
-		// request SecHub job state from server
-		response := sendWithDefaultHeader("GET", buildGetSecHubJobStatusAPICall(context), context)
-
-		data, err := ioutil.ReadAll(response.Body)
-		sechubUtil.HandleHTTPError(err, ExitCodeHTTPError)
-		if context.config.debug {
-			sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("get job status :%s", string(data)))
-		}
-
-		/* transform text to json */
-		err = json.Unmarshal(data, &status)
-		sechubUtil.HandleHTTPError(err, ExitCodeHTTPError)
+		status, _ = getSecHubJobStatus(context)
 
 		if status.State == ExecutionStateEnded {
-			done = true
-		}
-		if done {
-			if !checkTrafficLight {
-				return string(data)
-			}
 			break
-		} else {
-			// PROGRESS bar ... 50 chars with dot, then next line...
-			if newLine {
-				sechubUtil.PrintIfNotSilent(strings.Repeat(" ", 29), context.config.quiet)
-				newLine = false
-			}
-			sechubUtil.PrintIfNotSilent(".", context.config.quiet)
-			if cursor++; cursor == 50 {
-				sechubUtil.PrintIfNotSilent("\n", context.config.quiet)
-				cursor = 0
-				newLine = true
-			}
-			time.Sleep(time.Duration(context.config.waitNanoseconds))
 		}
+
+		// PROGRESS bar ... 50 chars with dot, then next line...
+		if newLine {
+			sechubUtil.PrintIfNotSilent(strings.Repeat(" ", 29), context.config.quiet)
+			newLine = false
+		}
+		sechubUtil.PrintIfNotSilent(".", context.config.quiet)
+		if cursor++; cursor == 50 {
+			sechubUtil.PrintIfNotSilent("\n", context.config.quiet)
+			cursor = 0
+			newLine = true
+		}
+		time.Sleep(time.Duration(context.config.waitNanoseconds))
 	}
 	sechubUtil.PrintIfNotSilent("\n", context.config.quiet)
 
-	if downloadReport {
-		downloadSechubReport(context)
+	return status
+}
+
+func getSecHubJobStatus(context *Context) (status jobStatusResult, jsonData string) {
+	// request SecHub job state from server
+	response := sendWithDefaultHeader("GET", buildGetSecHubJobStatusAPICall(context), context)
+
+	data, err := ioutil.ReadAll(response.Body)
+	sechubUtil.HandleHTTPError(err, ExitCodeHTTPError)
+	if context.config.debug {
+		sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("Get job status :%s", string(data)))
 	}
 
+	/* transform text to json */
+	err = json.Unmarshal(data, &status)
+	sechubUtil.HandleHTTPError(err, ExitCodeHTTPError)
+
+	return status, string(data)
+}
+
+func printSecHubJobSummaryAndFailOnTrafficLight(context *Context, status jobStatusResult) {
 	/* Evaluate traffic light */
 	switch status.TrafficLight {
 	case "RED":
@@ -129,7 +96,7 @@ func getSecHubJobState(context *Context, checkOnlyOnce bool, checkTrafficLight b
 		os.Exit(ExitCodeFailed)
 	case "YELLOW":
 		yellowMessage := "  YELLOW alert - security vulnerabilities identified (but not critical or high)"
-		if context.config.stopOnYellow == true {
+		if context.config.stopOnYellow {
 			fmt.Fprintln(os.Stderr, yellowMessage)
 			os.Exit(ExitCodeFailed)
 		} else {
@@ -144,5 +111,4 @@ func getSecHubJobState(context *Context, checkOnlyOnce bool, checkTrafficLight b
 		sechubUtil.LogError(fmt.Sprintln("UNKNOWN traffic light:", status.TrafficLight, "- Expected one of: RED, YELLOW, GREEN."))
 		os.Exit(ExitCodeFailed)
 	}
-	return ""
 }

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/urlbuilder.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/urlbuilder.go
@@ -15,7 +15,7 @@ func buildCreateNewSecHubJobAPICall(context *Context) string {
 
 // https://localhost:8443/api/project/testproject/job/e21b13fc-591e-4abd-b119-755d473c5625/approve
 func buildApproveSecHubJobAPICall(context *Context) string {
-
+	context.contentToSend = nil // Do not send content
 	apiPart := fmt.Sprintf("project/%s/job/%s/approve", context.config.projectID, context.config.secHubJobUUID)
 	return buildAPIUrl(&context.config.server, &apiPart)
 }
@@ -28,12 +28,14 @@ func buildUploadSourceCodeAPICall(context *Context) string {
 
 // https://localhost:8443/api/project/testproject/job/e21b13fc-591e-4abd-b119-755d473c5625
 func buildGetSecHubJobStatusAPICall(context *Context) string {
+	context.contentToSend = nil // Do not send content
 	apiPart := fmt.Sprintf("project/%s/job/%s", context.config.projectID, context.config.secHubJobUUID)
 	return buildAPIUrl(&context.config.server, &apiPart)
 }
 
 // https://localhost:8443/api/project/testproject/report/e21b13fc-591e-4abd-b119-755d473c5625
 func buildGetSecHubJobReportAPICall(context *Context) string {
+	context.contentToSend = nil // Do not send content
 	apiPart := fmt.Sprintf("project/%s/report/%s", context.config.projectID, context.config.secHubJobUUID)
 	return buildAPIUrl(&context.config.server, &apiPart)
 }


### PR DESCRIPTION
- send json only when creating a SecHub job
- refactoring of complex `waitForSecHubJobDoneAndFailOnTrafficLight`/`getSecHubJobState` into small simple functions
(Please look at complete file `job.go` because the diffs are rather confusing)

closes #290 