### PR TITLE
Avoid circular reference problem on container start, fixes #944

### DIFF
--- a/sechub-scan/src/main/java/com/daimler/sechub/domain/scan/ScanAssertService.java
+++ b/sechub-scan/src/main/java/com/daimler/sechub/domain/scan/ScanAssertService.java
@@ -2,6 +2,7 @@
 package com.daimler.sechub.domain.scan;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import com.daimler.sechub.domain.scan.access.ScanUserAccessToProjectValidationService;
@@ -21,6 +22,7 @@ public class ScanAssertService {
     @Autowired
     ScanUserAccessToProjectValidationService userAccessValidation;
 
+    @Lazy
     @Autowired
     ScanProjectConfigAccessLevelService accessLevelService;
     

--- a/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/ScheduleAssertService.java
+++ b/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/ScheduleAssertService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import com.daimler.sechub.domain.schedule.access.ScheduleUserAccessToProjectValidationService;
@@ -32,6 +33,7 @@ public class ScheduleAssertService {
     @Autowired
     ProjectWhiteListSecHubConfigurationValidationService executionIsInWhiteListValidation;
 
+    @Lazy
     @Autowired
     SchedulerProjectConfigService projectConfigService;
 

--- a/sechub-server/src/main/resources/application.yml
+++ b/sechub-server/src/main/resources/application.yml
@@ -44,8 +44,6 @@ spring:
   main:
     # see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
     allow-bean-definition-overriding: true
-    # see https://stackoverflow.com/questions/70036903/spring-boot-application-fails-to-start-after-upgrading-to-2-6-0-due-to-circular
-    allow-circular-references: true
   servlet: 
     # MultiPart file-size limits,
     # https://spring.io/guides/gs/uploading-files/


### PR DESCRIPTION
- some assert services where used by caller side but reuse them as well
- so it was not clear for the framework which one would be
  initialized first.
- To avoid this, the assert services get the callers injected lazy, so
  only necessary at runtime when instances are already created

This PR closes #944 