### PR TITLE
Feature 633 admin can change email address of user

### DIFF
--- a/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/AdministrationAPIConstants.java
+++ b/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/AdministrationAPIConstants.java
@@ -87,6 +87,8 @@ public class AdministrationAPIConstants {
 
     public static final String API_SHOW_USER_DETAILS = API_ADMINISTRATION + "user/{userId}";
     public static final String API_DELETE_USER = API_ADMINISTRATION + "user/{userId}";
+    public static final String API_UPDATE_USER_EMAIL_ADDRESS = API_ADMINISTRATION + "user/{userId}/email/{newEmailAddress}";
+    
     public static final String API_SHOW_PROJECT_DETAILS = API_ADMINISTRATION + "project/{projectId}";
     public static final String API_CHANGE_PROJECT_DETAILS = API_ADMINISTRATION + "project/{projectId}";
     public static final String API_DELETE_PROJECT = API_ADMINISTRATION + "project/{projectId}";
@@ -104,5 +106,6 @@ public class AdministrationAPIConstants {
     /* +-----------------------------------------------------------------------+ */
     public static final String API_FETCH_NEW_API_TOKEN_BY_ONE_WAY_TOKEN = API_ANONYMOUS + "apitoken";
     public static final String API_REQUEST_NEW_APITOKEN = API_ANONYMOUS + "refresh/apitoken/{emailAddress}";
+
 
 }

--- a/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/AdministrationAPIConstants.java
+++ b/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/AdministrationAPIConstants.java
@@ -88,7 +88,7 @@ public class AdministrationAPIConstants {
     public static final String API_SHOW_USER_DETAILS = API_ADMINISTRATION + "user/{userId}";
     public static final String API_DELETE_USER = API_ADMINISTRATION + "user/{userId}";
     public static final String API_UPDATE_USER_EMAIL_ADDRESS = API_ADMINISTRATION + "user/{userId}/email/{newEmailAddress}";
-    
+
     public static final String API_SHOW_PROJECT_DETAILS = API_ADMINISTRATION + "project/{projectId}";
     public static final String API_CHANGE_PROJECT_DETAILS = API_ADMINISTRATION + "project/{projectId}";
     public static final String API_DELETE_PROJECT = API_ADMINISTRATION + "project/{projectId}";
@@ -106,6 +106,5 @@ public class AdministrationAPIConstants {
     /* +-----------------------------------------------------------------------+ */
     public static final String API_FETCH_NEW_API_TOKEN_BY_ONE_WAY_TOKEN = API_ANONYMOUS + "apitoken";
     public static final String API_REQUEST_NEW_APITOKEN = API_ANONYMOUS + "refresh/apitoken/{emailAddress}";
-
 
 }

--- a/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserAdministrationRestController.java
+++ b/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserAdministrationRestController.java
@@ -27,6 +27,7 @@ import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminList
 import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminListsAllUsers;
 import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminRevokesAdminRightsFromAdmin;
 import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminShowsUserDetails;
+import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminUpdatesUserEmailAddress;
 
 /**
  * The rest api for user administration done by a super admin.
@@ -57,6 +58,9 @@ public class UserAdministrationRestController {
 
     @Autowired
     UserRevokeSuperAdminRightsService userRevokeSuperAdminRightsService;
+    
+    @Autowired
+    UserEmailAddressUpdateService userEmailAddressUpdateService;
 
     /* @formatter:off */
 	@UseCaseAdminAcceptsSignup(@Step(number=1,name="Rest call", description="Administrator accepts a persisted self registration entry by calling rest api",needsRestDoc=true))
@@ -113,6 +117,14 @@ public class UserAdministrationRestController {
 	public void revokeSuperAdminrights(@PathVariable(name="userId") String userId) {
 		/* @formatter:on */
         userRevokeSuperAdminRightsService.revokeSuperAdminRightsFrom(userId);
+    }
+	
+	 /* @formatter:off */
+    @UseCaseAdminUpdatesUserEmailAddress(@Step(number=1,name="Rest call",description="User emaill address will be changed",needsRestDoc=true))
+    @RequestMapping(path = AdministrationAPIConstants.API_UPDATE_USER_EMAIL_ADDRESS, method = RequestMethod.PUT, produces= {MediaType.APPLICATION_JSON_VALUE})
+    public void updateUserEmailAdderss(@PathVariable(name="userId") String userId,@PathVariable(name="newEmailAddress") String newEmailAddress) {
+        /* @formatter:on */
+        userEmailAddressUpdateService.updateUserEmailAddress(userId, newEmailAddress);
     }
 
 }

--- a/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserAdministrationRestController.java
+++ b/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserAdministrationRestController.java
@@ -58,7 +58,7 @@ public class UserAdministrationRestController {
 
     @Autowired
     UserRevokeSuperAdminRightsService userRevokeSuperAdminRightsService;
-    
+
     @Autowired
     UserEmailAddressUpdateService userEmailAddressUpdateService;
 
@@ -118,8 +118,8 @@ public class UserAdministrationRestController {
 		/* @formatter:on */
         userRevokeSuperAdminRightsService.revokeSuperAdminRightsFrom(userId);
     }
-	
-	 /* @formatter:off */
+
+    /* @formatter:off */
     @UseCaseAdminUpdatesUserEmailAddress(@Step(number=1,name="Rest call",description="User emaill address will be changed",needsRestDoc=true))
     @RequestMapping(path = AdministrationAPIConstants.API_UPDATE_USER_EMAIL_ADDRESS, method = RequestMethod.PUT, produces= {MediaType.APPLICATION_JSON_VALUE})
     public void updateUserEmailAdderss(@PathVariable(name="userId") String userId,@PathVariable(name="newEmailAddress") String newEmailAddress) {

--- a/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateService.java
+++ b/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateService.java
@@ -55,17 +55,16 @@ public class UserEmailAddressUpdateService {
         assertion.isValidUserId(userId);
         assertion.isValidEmailAddress(newEmailAddress);
 
-
         User user = userRepository.findOrFailUser(userId);
-        String formerEmailAddress=user.getEmailAdress();
-        
+        String formerEmailAddress = user.getEmailAdress();
+
         if (newEmailAddress.equalsIgnoreCase(formerEmailAddress)) {
             throw new NotAcceptableException("User has already this email address");
         }
-        /* parameters valid, we audit log the change*/
+        /* parameters valid, we audit log the change */
         auditLogService.log("Changed email adress of user {}", logSanitizer.sanitize(userId, 30));
 
-        user.emailAdress=newEmailAddress;
+        user.emailAdress = newEmailAddress;
 
         /* create message containing data before user email has changed */
         UserMessage message = new UserMessage();

--- a/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateService.java
+++ b/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateService.java
@@ -47,7 +47,7 @@ public class UserEmailAddressUpdateService {
 			@Step(
 					number = 2,
 					name = "Service updates user email address.",
-					next = { 3,	4 },
+					next = { 3 },
 					description = "The service will update the user email address and also trigger events."))
 	/* @formatter:on */
     @Transactional
@@ -72,7 +72,7 @@ public class UserEmailAddressUpdateService {
         message.setUserId(user.getName());
         message.setEmailAdress(user.getEmailAdress());
         message.setFormerEmailAddress(formerEmailAddress);
-        message.setSubject("An administrator has changed your SecHub email-adress");
+        message.setSubject("A SecHub administrator has changed your email address");
 
         userRepository.save(user);
 
@@ -83,7 +83,7 @@ public class UserEmailAddressUpdateService {
     @IsSendingAsyncMessage(MessageID.USER_EMAIL_ADDRESS_CHANGED)
     private void informUserEmailAddressUpdated(UserMessage message) {
 
-        DomainMessage infoRequest = new DomainMessage(MessageID.USER_DELETED);
+        DomainMessage infoRequest = new DomainMessage(MessageID.USER_EMAIL_ADDRESS_CHANGED);
         infoRequest.set(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA, message);
 
         eventBusService.sendAsynchron(infoRequest);

--- a/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateService.java
+++ b/sechub-administration/src/main/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateService.java
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+package com.mercedesbenz.sechub.domain.administration.user;
+
+import javax.annotation.security.RolesAllowed;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import com.mercedesbenz.sechub.sharedkernel.RoleConstants;
+import com.mercedesbenz.sechub.sharedkernel.Step;
+import com.mercedesbenz.sechub.sharedkernel.error.NotAcceptableException;
+import com.mercedesbenz.sechub.sharedkernel.logging.AuditLogService;
+import com.mercedesbenz.sechub.sharedkernel.logging.LogSanitizer;
+import com.mercedesbenz.sechub.sharedkernel.messaging.DomainMessage;
+import com.mercedesbenz.sechub.sharedkernel.messaging.DomainMessageService;
+import com.mercedesbenz.sechub.sharedkernel.messaging.IsSendingAsyncMessage;
+import com.mercedesbenz.sechub.sharedkernel.messaging.MessageDataKeys;
+import com.mercedesbenz.sechub.sharedkernel.messaging.MessageID;
+import com.mercedesbenz.sechub.sharedkernel.messaging.UserMessage;
+import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminUpdatesUserEmailAddress;
+import com.mercedesbenz.sechub.sharedkernel.validation.UserInputAssertion;
+
+@Service
+@RolesAllowed(RoleConstants.ROLE_SUPERADMIN)
+public class UserEmailAddressUpdateService {
+
+    @Autowired
+    DomainMessageService eventBusService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AuditLogService auditLogService;
+
+    @Autowired
+    LogSanitizer logSanitizer;
+
+    @Autowired
+    UserInputAssertion assertion;
+
+    /* @formatter:off */
+	@Validated
+	@UseCaseAdminUpdatesUserEmailAddress(
+			@Step(
+					number = 2,
+					name = "Service updates user email address.",
+					next = { 3,	4 },
+					description = "The service will update the user email address and also trigger events."))
+	/* @formatter:on */
+    @Transactional
+    public void updateUserEmailAddress(String userId, String newEmailAddress) {
+        assertion.isValidUserId(userId);
+        assertion.isValidEmailAddress(newEmailAddress);
+
+
+        User user = userRepository.findOrFailUser(userId);
+        String formerEmailAddress=user.getEmailAdress();
+        
+        if (newEmailAddress.equalsIgnoreCase(formerEmailAddress)) {
+            throw new NotAcceptableException("User has already this email address");
+        }
+        /* parameters valid, we audit log the change*/
+        auditLogService.log("Changed email adress of user {}", logSanitizer.sanitize(userId, 30));
+
+        user.emailAdress=newEmailAddress;
+
+        /* create message containing data before user email has changed */
+        UserMessage message = new UserMessage();
+        message.setUserId(user.getName());
+        message.setEmailAdress(user.getEmailAdress());
+        message.setFormerEmailAddress(formerEmailAddress);
+        message.setSubject("An administrator has changed your SecHub email-adress");
+
+        userRepository.save(user);
+
+        informUserEmailAddressUpdated(message);
+
+    }
+
+    @IsSendingAsyncMessage(MessageID.USER_EMAIL_ADDRESS_CHANGED)
+    private void informUserEmailAddressUpdated(UserMessage message) {
+
+        DomainMessage infoRequest = new DomainMessage(MessageID.USER_DELETED);
+        infoRequest.set(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA, message);
+
+        eventBusService.sendAsynchron(infoRequest);
+    }
+
+}

--- a/sechub-administration/src/test/java/com/mercedesbenz/sechub/domain/administration/user/UserAdministrationRestControllerMockTest.java
+++ b/sechub-administration/src/test/java/com/mercedesbenz/sechub/domain/administration/user/UserAdministrationRestControllerMockTest.java
@@ -71,6 +71,9 @@ public class UserAdministrationRestControllerMockTest {
     private UserRevokeSuperAdminRightsService userRevokeSuperAdminRightsService;
 
     @MockBean
+    private UserEmailAddressUpdateService userEmailAddressUpdateService;
+
+    @MockBean
     UserListService mockedUserListService;
 
     @Test

--- a/sechub-administration/src/test/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateServiceTest.java
+++ b/sechub-administration/src/test/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateServiceTest.java
@@ -1,0 +1,202 @@
+package com.mercedesbenz.sechub.domain.administration.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.mercedesbenz.sechub.sharedkernel.error.NotAcceptableException;
+import com.mercedesbenz.sechub.sharedkernel.error.NotFoundException;
+import com.mercedesbenz.sechub.sharedkernel.logging.AuditLogService;
+import com.mercedesbenz.sechub.sharedkernel.logging.LogSanitizer;
+import com.mercedesbenz.sechub.sharedkernel.messaging.DomainMessage;
+import com.mercedesbenz.sechub.sharedkernel.messaging.DomainMessageService;
+import com.mercedesbenz.sechub.sharedkernel.messaging.MessageDataKeys;
+import com.mercedesbenz.sechub.sharedkernel.messaging.UserMessage;
+import com.mercedesbenz.sechub.sharedkernel.validation.UserInputAssertion;
+import com.mercedesbenz.sechub.test.TestCanaryException;
+
+class UserEmailAddressUpdateServiceTest {
+
+    private static final String KNOWN_USER1 = "knownUser1";
+    private UserEmailAddressUpdateService serviceToTest;
+    private UserInputAssertion assertion;
+    private AuditLogService auditLogService;
+    private DomainMessageService eventBusService;
+    private UserRepository userRepository;
+    private LogSanitizer logSanitizer;
+
+    @BeforeEach
+    void beforeEach() {
+        serviceToTest = new UserEmailAddressUpdateService();
+
+        assertion = mock(UserInputAssertion.class);
+        auditLogService = mock(AuditLogService.class);
+        eventBusService = mock(DomainMessageService.class);
+        userRepository = mock(UserRepository.class);
+        logSanitizer = mock(LogSanitizer.class);
+
+        serviceToTest.assertion = assertion;
+        serviceToTest.auditLogService = auditLogService;
+        serviceToTest.logSanitizer = logSanitizer;
+        serviceToTest.eventBusService = eventBusService;
+        serviceToTest.userRepository = userRepository;
+    }
+
+    @Test
+    void audit_log_is_called_with_sanitized_user_id_when_user_was_found() {
+        /* prepare */
+        User knownUser1 = createKnownUser1();
+        when(userRepository.findOrFailUser(KNOWN_USER1)).thenReturn(knownUser1);
+        when(logSanitizer.sanitize(knownUser1.getName(), 30)).thenReturn("sanitized-userid");
+
+        /* execute */
+        serviceToTest.updateUserEmailAddress(KNOWN_USER1, "new.user1@example.com");
+
+        /* test */
+        verify(auditLogService).log(any(String.class), eq("sanitized-userid"));
+    }
+
+    @Test
+    void audit_log_is_NOT_called_when_user_not_found() {
+        /* prepare */
+        when(userRepository.findOrFailUser("notfound")).thenThrow(TestCanaryException.class);
+
+        /* execute */
+        assertThrows(TestCanaryException.class, () -> serviceToTest.updateUserEmailAddress("notfound", "new.user1@example.com"));
+
+        /* test */
+        verify(auditLogService, never()).log(any(String.class), any());
+    }
+
+    @Test
+    void asserts_email_address_parameter() {
+        /* prepare - just to have no NPE while testing with mock data */
+        User knownUser1 = createKnownUser1();
+        when(userRepository.findOrFailUser(KNOWN_USER1)).thenReturn(knownUser1);
+
+        /* execute */
+        serviceToTest.updateUserEmailAddress(KNOWN_USER1, "new.user1@example.com");
+
+        /* test */
+        verify(assertion).isValidEmailAddress("new.user1@example.com");
+    }
+
+    @Test
+    void asserts_user_id_parameter() {
+        /* prepare - just to have no NPE while testing with mock data */
+        User knownUser1 = createKnownUser1();
+        when(userRepository.findOrFailUser(KNOWN_USER1)).thenReturn(knownUser1);
+
+        /* execute */
+        serviceToTest.updateUserEmailAddress(KNOWN_USER1, "new.user1@example.com");
+
+        /* test */
+        verify(assertion).isValidUserId(KNOWN_USER1);
+    }
+
+    @Test
+    void asserts_user_id_parameter_before_user_is_fetched_from_db() {
+        /* prepare - just to have no NPE while testing with mock data */
+        when(userRepository.findOrFailUser("notfound")).thenThrow(NotFoundException.class);
+        doThrow(TestCanaryException.class).when(assertion).isValidUserId(any());
+
+        /* execute + test */
+        assertThrows(TestCanaryException.class, () -> serviceToTest.updateUserEmailAddress("novalid", "former.user1@example.com"));
+    }
+
+    @Test
+    void asserts_email_parameter_before_user_is_fetched_from_db() {
+        /* prepare - just to have no NPE while testing with mock data */
+        when(userRepository.findOrFailUser("notfound")).thenThrow(NotFoundException.class);
+        doThrow(TestCanaryException.class).when(assertion).isValidEmailAddress(any());
+
+        /* execute + test */
+        assertThrows(TestCanaryException.class, () -> serviceToTest.updateUserEmailAddress("notfound", "not-a-valid-email-adress"));
+    }
+
+    @Test
+    void when_assertions_do_not_handle_null_userid_user_repository_would_be_called_without_npe() {
+        /* prepare */
+        when(userRepository.findOrFailUser(null)).thenThrow(TestCanaryException.class);
+
+        /* execute */
+        assertThrows(TestCanaryException.class, () -> serviceToTest.updateUserEmailAddress(null, "something"));
+    }
+
+    @Test
+    void when_assertions_do_not_handle_null_email_user_repository_would_be_called_without_npe() {
+        /* prepare */
+        when(userRepository.findOrFailUser("somebody")).thenThrow(TestCanaryException.class);
+
+        /* execute */
+        assertThrows(TestCanaryException.class, () -> serviceToTest.updateUserEmailAddress("somebody", null));
+    }
+
+    @Test
+    void throws_not_acceptable_when_same_mail_adress_as_before() {
+        /* prepare */
+        User knownUser1 = createKnownUser1();
+        when(userRepository.findOrFailUser(KNOWN_USER1)).thenReturn(knownUser1);
+
+        /* execute + test (exception ) */
+        assertThrows(NotAcceptableException.class, () -> serviceToTest.updateUserEmailAddress(KNOWN_USER1, "former.user1@example.com"));
+    }
+
+    @Test
+    void throws_exception_when_user_not_found() {
+        /* prepare */
+        when(userRepository.findOrFailUser(any())).thenThrow(NotFoundException.class);
+
+        /* execute + test (exception ) */
+        assertThrows(NotFoundException.class, () -> serviceToTest.updateUserEmailAddress("notfound", "new.user1@example.com"));
+    }
+
+    @Test
+    void saves_user_when_parameters_are_valid() {
+        /* prepare */
+        User knownUser1 = createKnownUser1();
+        when(userRepository.findOrFailUser(KNOWN_USER1)).thenReturn(knownUser1);
+
+        /* execute */
+        serviceToTest.updateUserEmailAddress(KNOWN_USER1, "new.user1@example.com");
+
+        /* test */
+        // check the user object has new mail address when saved:
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertEquals("new.user1@example.com", userCaptor.getValue().getEmailAdress());
+    }
+
+    @Test
+    void sends_event_with_user_data_when_parameters_are_valid() {
+        /* prepare */
+        User knownUser1 = createKnownUser1();
+        when(userRepository.findOrFailUser(KNOWN_USER1)).thenReturn(knownUser1);
+
+        /* execute */
+        serviceToTest.updateUserEmailAddress(KNOWN_USER1, "new.user1@example.com");
+
+        /* test */
+        // check event is sent with expected data
+        ArgumentCaptor<DomainMessage> messageCaptor = ArgumentCaptor.forClass(DomainMessage.class);
+        verify(eventBusService).sendAsynchron(messageCaptor.capture());
+        UserMessage userMessage = messageCaptor.getValue().get(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA);
+        assertNotNull(userMessage);
+
+        assertEquals(KNOWN_USER1, userMessage.getUserId());
+        assertEquals("new.user1@example.com", userMessage.getEmailAdress());
+        assertEquals("former.user1@example.com", userMessage.getFormerEmailAddress());
+    }
+
+    private User createKnownUser1() {
+        User user = new User();
+        user.name = KNOWN_USER1;
+        user.emailAdress = "former.user1@example.com";
+        return user;
+    }
+
+}

--- a/sechub-administration/src/test/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateServiceTest.java
+++ b/sechub-administration/src/test/java/com/mercedesbenz/sechub/domain/administration/user/UserEmailAddressUpdateServiceTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 package com.mercedesbenz.sechub.domain.administration.user;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/sechub-developertools/src/main/java/com/mercedesbenz/sechub/developertools/admin/DeveloperAdministration.java
+++ b/sechub-developertools/src/main/java/com/mercedesbenz/sechub/developertools/admin/DeveloperAdministration.java
@@ -555,6 +555,11 @@ public class DeveloperAdministration {
         return "sent";
     }
 
+    public String changeUserEmailAddress(String userId, String newEmailAddress) {
+        asTestUser().changeEmailAddress(userId, newEmailAddress);
+        return "sent";
+    }
+
     public String cancelJob(UUID jobUUID) {
         getRestHelper().post(getUrlBuilder().buildAdminCancelsJob(jobUUID));
         return "cancel triggered";

--- a/sechub-developertools/src/main/java/com/mercedesbenz/sechub/developertools/admin/ui/CommandUI.java
+++ b/sechub-developertools/src/main/java/com/mercedesbenz/sechub/developertools/admin/ui/CommandUI.java
@@ -103,6 +103,7 @@ import com.mercedesbenz.sechub.developertools.admin.ui.action.user.ListSignupsAc
 import com.mercedesbenz.sechub.developertools.admin.ui.action.user.ShowAdminListAction;
 import com.mercedesbenz.sechub.developertools.admin.ui.action.user.ShowUserDetailAction;
 import com.mercedesbenz.sechub.developertools.admin.ui.action.user.ShowUserListAction;
+import com.mercedesbenz.sechub.developertools.admin.ui.action.user.UpdateUserEmailAction;
 import com.mercedesbenz.sechub.developertools.admin.ui.action.user.privileges.GrantAdminRightsToUserAction;
 import com.mercedesbenz.sechub.developertools.admin.ui.action.user.privileges.RevokeAdminRightsFromAdminAction;
 import com.mercedesbenz.sechub.domain.scan.product.ProductIdentifier;
@@ -291,6 +292,7 @@ public class CommandUI {
         add(menu, new DeleteUserAction(context));
         menu.addSeparator();
         add(menu, new ShowUserDetailAction(context));
+        add(menu, new UpdateUserEmailAction(context));
         add(menu, new AnonymousRequestNewAPITokenUserAction(context));
         menu.addSeparator();
         add(menu, new ListSignupsAction(context));

--- a/sechub-developertools/src/main/java/com/mercedesbenz/sechub/developertools/admin/ui/action/user/UpdateUserEmailAction.java
+++ b/sechub-developertools/src/main/java/com/mercedesbenz/sechub/developertools/admin/ui/action/user/UpdateUserEmailAction.java
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+package com.mercedesbenz.sechub.developertools.admin.ui.action.user;
+
+import java.awt.event.ActionEvent;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mercedesbenz.sechub.developertools.admin.ui.UIContext;
+import com.mercedesbenz.sechub.developertools.admin.ui.action.AbstractUIAction;
+import com.mercedesbenz.sechub.developertools.admin.ui.cache.InputCacheIdentifier;
+
+public class UpdateUserEmailAction extends AbstractUIAction {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateUserEmailAction.class);
+
+    public UpdateUserEmailAction(UIContext context) {
+        super("Update user email address", context);
+    }
+
+    @Override
+    public void execute(ActionEvent e) {
+        Optional<String> optUserId = getUserInput("Please enter userid for user whose email address you want to change.", InputCacheIdentifier.USERNAME);
+        if (!optUserId.isPresent()) {
+            return;
+        }
+        String userId = optUserId.get().toLowerCase().trim();
+
+        Optional<String> optNewEmailAddress = getUserInput("Please enter new email address for user " + userId);
+        if (!optNewEmailAddress.isPresent()) {
+            return;
+        }
+        String newEmailAddress = optNewEmailAddress.get().toLowerCase().trim();
+
+        if (!confirm("Do you really want to\nCHANGE EMAIL ADDRESS of \nuser " + userId + " to '" + newEmailAddress + "'?")) {
+            outputAsTextOnSuccess("CANCELED - delete");
+            LOG.info("canceled email change of user {} to {}", userId, newEmailAddress);
+            return;
+        }
+        LOG.info("start change user {} email to {}", userId, newEmailAddress);
+        String infoMessage = getContext().getAdministration().changeUserEmailAddress(userId, newEmailAddress);
+        outputAsTextOnSuccess(infoMessage);
+    }
+
+}

--- a/sechub-doc/src/docs/asciidoc/documents/code2doc/usecases/admin/updateUserEmailAddress.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/code2doc/usecases/admin/updateUserEmailAddress.adoc
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+An administrator update the email address of an user. After the change an email will be 
+sent to the old email-address to inform the user about the change. In addition, a new mail to
+the new email address will be sent as well.
+
+[NOTE]
+====
+When the new email address is the same as before, the action will be rejected.
+
+====
+

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/UserAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/UserAdministrationRestControllerRestDocTest.java
@@ -95,7 +95,7 @@ public class UserAdministrationRestControllerRestDocTest {
 
     @MockBean
     private UserEmailAddressUpdateService userEmailAddressUpdateService;
-    
+
     @MockBean
     private SignupRepository signUpRepository;
 
@@ -107,7 +107,7 @@ public class UserAdministrationRestControllerRestDocTest {
     @UseCaseRestDoc(useCase = UseCaseAdminUpdatesUserEmailAddress.class)
     public void restdoc_admin_updates_user_email_address() throws Exception {
         /* prepare */
-        String apiEndpoint = https(PORT_USED).buildAdminChangesUserEmailAddress(USER_ID.pathElement(),EMAIL_ADDRESS.pathElement());
+        String apiEndpoint = https(PORT_USED).buildAdminChangesUserEmailAddress(USER_ID.pathElement(), EMAIL_ADDRESS.pathElement());
         Class<? extends Annotation> useCase = UseCaseAdminUpdatesUserEmailAddress.class;
 
         /* execute + test @formatter:off */
@@ -124,7 +124,7 @@ public class UserAdministrationRestControllerRestDocTest {
                             pathParameters(
                                     parameterWithName(USER_ID.paramName()).description("The userId of the user whose email adress will be changed"),
                                     parameterWithName(EMAIL_ADDRESS.paramName()).description("The new email address")
-                                    
+
                             ).
                             build()
                         )
@@ -132,7 +132,7 @@ public class UserAdministrationRestControllerRestDocTest {
 
         /* @formatter:on */
     }
-    
+
     @Test
     @UseCaseRestDoc(useCase = UseCaseAdminGrantsAdminRightsToUser.class)
     public void restdoc_grant_admin_rights_to_user() throws Exception {

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/UserAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/UserAdministrationRestControllerRestDocTest.java
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: MIT
 package com.mercedesbenz.sechub.restdoc;
 
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static com.mercedesbenz.sechub.test.TestURLBuilder.*;
 import static com.mercedesbenz.sechub.test.TestURLBuilder.RestDocPathParameter.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.lang.annotation.Annotation;
 import java.util.LinkedHashSet;
@@ -45,6 +42,7 @@ import com.mercedesbenz.sechub.domain.administration.user.UserCreationService;
 import com.mercedesbenz.sechub.domain.administration.user.UserDeleteService;
 import com.mercedesbenz.sechub.domain.administration.user.UserDetailInformation;
 import com.mercedesbenz.sechub.domain.administration.user.UserDetailInformationService;
+import com.mercedesbenz.sechub.domain.administration.user.UserEmailAddressUpdateService;
 import com.mercedesbenz.sechub.domain.administration.user.UserGrantSuperAdminRightsService;
 import com.mercedesbenz.sechub.domain.administration.user.UserListService;
 import com.mercedesbenz.sechub.domain.administration.user.UserRevokeSuperAdminRightsService;
@@ -59,6 +57,7 @@ import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminList
 import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminListsAllUsers;
 import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminRevokesAdminRightsFromAdmin;
 import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminShowsUserDetails;
+import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminUpdatesUserEmailAddress;
 import com.mercedesbenz.sechub.test.ExampleConstants;
 import com.mercedesbenz.sechub.test.TestPortProvider;
 import com.mercedesbenz.sechub.test.TestURLBuilder;
@@ -95,12 +94,45 @@ public class UserAdministrationRestControllerRestDocTest {
     private UserRevokeSuperAdminRightsService userRevokeSuperAdminRightsService;
 
     @MockBean
+    private UserEmailAddressUpdateService userEmailAddressUpdateService;
+    
+    @MockBean
     private SignupRepository signUpRepository;
 
     @Before
     public void before() {
     }
 
+    @Test
+    @UseCaseRestDoc(useCase = UseCaseAdminUpdatesUserEmailAddress.class)
+    public void restdoc_admin_updates_user_email_address() throws Exception {
+        /* prepare */
+        String apiEndpoint = https(PORT_USED).buildAdminChangesUserEmailAddress(USER_ID.pathElement(),EMAIL_ADDRESS.pathElement());
+        Class<? extends Annotation> useCase = UseCaseAdminUpdatesUserEmailAddress.class;
+
+        /* execute + test @formatter:off */
+        this.mockMvc.perform(
+                put(apiEndpoint, USER_ID, EMAIL_ADDRESS)
+                )./*andDo(print()).*/
+        andExpect(status().isOk()).
+        andDo(document(RestDocFactory.createPath(useCase),
+                resource(
+                        ResourceSnippetParameters.builder().
+                            summary(RestDocFactory.createSummary(useCase)).
+                            description(RestDocFactory.createDescription(useCase)).
+                            tag(RestDocFactory.extractTag(apiEndpoint)).
+                            pathParameters(
+                                    parameterWithName(USER_ID.paramName()).description("The userId of the user whose email adress will be changed"),
+                                    parameterWithName(EMAIL_ADDRESS.paramName()).description("The new email address")
+                                    
+                            ).
+                            build()
+                        )
+                ));
+
+        /* @formatter:on */
+    }
+    
     @Test
     @UseCaseRestDoc(useCase = UseCaseAdminGrantsAdminRightsToUser.class)
     public void restdoc_grant_admin_rights_to_user() throws Exception {

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AsUser.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AsUser.java
@@ -1059,7 +1059,7 @@ public class AsUser {
     }
 
     public void changeEmailAddress(TestUser user, String newEmailAddress) {
-        String url = getUrlBuilder().buildAdminChangesUserEmailAddress(user.getUserId(),newEmailAddress);
+        String url = getUrlBuilder().buildAdminChangesUserEmailAddress(user.getUserId(), newEmailAddress);
         getRestHelper().put(url);
     }
 

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AsUser.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AsUser.java
@@ -1059,7 +1059,11 @@ public class AsUser {
     }
 
     public void changeEmailAddress(TestUser user, String newEmailAddress) {
-        String url = getUrlBuilder().buildAdminChangesUserEmailAddress(user.getUserId(), newEmailAddress);
+        changeEmailAddress(user.getUserId(), newEmailAddress);
+    }
+
+    public void changeEmailAddress(String userId, String newEmailAddress) {
+        String url = getUrlBuilder().buildAdminChangesUserEmailAddress(userId, newEmailAddress);
         getRestHelper().put(url);
     }
 

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AsUser.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AsUser.java
@@ -1052,4 +1052,15 @@ public class AsUser {
         getRestHelper().post(url);
     }
 
+    public TestUserDetailInformation fetchUserDetails(TestUser user) {
+        String url = getUrlBuilder().buildAdminShowsUserDetailsUrl(user.getUserId());
+        String json = getRestHelper().getJSON(url);
+        return TestJSONHelper.get().createFromJSON(json, TestUserDetailInformation.class);
+    }
+
+    public void changeEmailAddress(TestUser user, String newEmailAddress) {
+        String url = getUrlBuilder().buildAdminChangesUserEmailAddress(user.getUserId(),newEmailAddress);
+        getRestHelper().put(url);
+    }
+
 }

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertMail.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertMail.java
@@ -39,8 +39,8 @@ public class AssertMail {
     /**
      * Assert mail to given test user exists
      *
-     * @param to                  test user
-     * @param subject             subject of mail
+     * @param to                test user
+     * @param subject           subject of mail
      * @param subjectSearchMode
      */
     public static void assertMailExists(TestUser to, String subject, TextSearchMode subjectSearchMode) {
@@ -51,7 +51,7 @@ public class AssertMail {
      * Assert that a mail send to administrator email address exist. An admin email
      * is normally a NPM or a mail distribution address
      *
-     * @param subject             subject of mail
+     * @param subject           subject of mail
      * @param subjectSearchMode
      */
     public static void assertMailToAdminsExists(String subject, TextSearchMode subjectSearchMode) {
@@ -61,12 +61,12 @@ public class AssertMail {
     /**
      * Assert mail to address exists
      *
-     * @param to                  mail address
-     * @param subject             subject of mail
+     * @param to                mail address
+     * @param subject           subject of mail
      * @param subjectSearchMode
      */
     public static void assertMailExists(String to, String subject, TextSearchMode subjectSearchMode) {
         IntegrationTestContext.get().emailAccess().findMailOrFail(to, subject, subjectSearchMode, MockEmailAccess.DEFAULT_TIMEOUT);
     }
-    
+
 }

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertMail.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertMail.java
@@ -33,7 +33,7 @@ public class AssertMail {
      * @param subject subject of mail
      */
     public static void assertMailExists(String to, String subject) {
-        assertMailExists(to, subject, false);
+        assertMailExists(to, subject, TextSearchMode.EXACT);
     }
 
     /**
@@ -41,11 +41,10 @@ public class AssertMail {
      *
      * @param to                  test user
      * @param subject             subject of mail
-     * @param asRegularExpression if <code>true</code> then the subject string is
-     *                            used as a regular expression.
+     * @param subjectSearchMode
      */
-    public static void assertMailExists(TestUser to, String subject, boolean asRegularExpression) {
-        assertMailExists(to.getEmail(), subject, asRegularExpression);
+    public static void assertMailExists(TestUser to, String subject, TextSearchMode subjectSearchMode) {
+        assertMailExists(to.getEmail(), subject, subjectSearchMode);
     }
 
     /**
@@ -53,11 +52,10 @@ public class AssertMail {
      * is normally a NPM or a mail distribution address
      *
      * @param subject             subject of mail
-     * @param asRegularExpression if <code>true</code> then the subject string is
-     *                            used as a regular expression.
+     * @param subjectSearchMode
      */
-    public static void assertMailToAdminsExists(String subject, boolean asRegularExpression) {
-        assertMailExists("int-test_superadmins_npm@example.org", subject, asRegularExpression);
+    public static void assertMailToAdminsExists(String subject, TextSearchMode subjectSearchMode) {
+        assertMailExists("int-test_superadmins_npm@example.org", subject, subjectSearchMode);
     }
 
     /**
@@ -65,11 +63,10 @@ public class AssertMail {
      *
      * @param to                  mail address
      * @param subject             subject of mail
-     * @param asRegularExpression if <code>true</code> then the subject string is
-     *                            used as a regular expression.
+     * @param subjectSearchMode
      */
-    public static void assertMailExists(String to, String subject, boolean asRegularExpression) {
-        IntegrationTestContext.get().emailAccess().findMailOrFail(to, subject, asRegularExpression, MockEmailAccess.DEFAULT_TIMEOUT);
+    public static void assertMailExists(String to, String subject, TextSearchMode subjectSearchMode) {
+        IntegrationTestContext.get().emailAccess().findMailOrFail(to, subject, subjectSearchMode, MockEmailAccess.DEFAULT_TIMEOUT);
     }
-
+    
 }

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertUser.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertUser.java
@@ -518,8 +518,8 @@ public class AssertUser extends AbstractAssert {
         return this;
     }
 
-    public AssertUser hasReceivedEmail(String subject, boolean asRegularExpression) {
-        AssertMail.assertMailExists(user.getEmail(), subject, asRegularExpression);
+    public AssertUser hasReceivedEmail(String subject, TextSearchMode subjectSearchMode) {
+        AssertMail.assertMailExists(user.getEmail(), subject, subjectSearchMode);
         return this;
     }
 

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TestUserDetailInformation.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TestUserDetailInformation.java
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+package com.mercedesbenz.sechub.integrationtest.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestUserDetailInformation {
+
+    private String userId;
+
+    private String email;
+
+    private boolean superAdmin;
+
+    private List<String> projects = new ArrayList<>();
+
+    private List<String> ownedProjects = new ArrayList<>();
+
+    public List<String> getProjects() {
+        return projects;
+    }
+
+    public List<String> getOwnedProjects() {
+        return ownedProjects;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public boolean isSuperAdmin() {
+        return superAdmin;
+    }
+
+}

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TextSearchMode.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TextSearchMode.java
@@ -1,6 +1,7 @@
 package com.mercedesbenz.sechub.integrationtest.api;
 
 public enum TextSearchMode {
+
     /**
      * Results only accepted when inspected text is exactly the same as search
      * string.
@@ -17,5 +18,6 @@ public enum TextSearchMode {
      * Results are accepted when the given search regular expression matches with
      * inspected text
      */
-    REGLAR_EXPRESSON,
+    REGULAR_EXPRESSON,
+
 }

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TextSearchMode.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TextSearchMode.java
@@ -1,0 +1,18 @@
+package com.mercedesbenz.sechub.integrationtest.api;
+
+public enum TextSearchMode{
+    /**
+     * Results only accepted when inspected text is exactly the same as search string.
+     */
+    EXACT,
+    
+    /**
+     * Results are accepted when the given search string is contained inside inspected text.
+     */
+    CONTAINS,
+    
+    /**
+     * Results are accepted when the given search regular expression matches with inspected text
+     */
+    REGLAR_EXPRESSON,
+}

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TextSearchMode.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/TextSearchMode.java
@@ -1,18 +1,21 @@
 package com.mercedesbenz.sechub.integrationtest.api;
 
-public enum TextSearchMode{
+public enum TextSearchMode {
     /**
-     * Results only accepted when inspected text is exactly the same as search string.
+     * Results only accepted when inspected text is exactly the same as search
+     * string.
      */
     EXACT,
-    
+
     /**
-     * Results are accepted when the given search string is contained inside inspected text.
+     * Results are accepted when the given search string is contained inside
+     * inspected text.
      */
     CONTAINS,
-    
+
     /**
-     * Results are accepted when the given search regular expression matches with inspected text
+     * Results are accepted when the given search regular expression matches with
+     * inspected text
      */
     REGLAR_EXPRESSON,
 }

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/MockEmailAccess.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/MockEmailAccess.java
@@ -11,8 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import com.mercedesbenz.sechub.integrationtest.api.MockEmailEntry;
-import com.mercedesbenz.sechub.integrationtest.api.TextSearchMode;
 import com.mercedesbenz.sechub.integrationtest.api.TestUser;
+import com.mercedesbenz.sechub.integrationtest.api.TextSearchMode;
 import com.mercedesbenz.sechub.test.TestURLBuilder;
 
 public class MockEmailAccess {

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/MockEmailAccess.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/MockEmailAccess.java
@@ -66,7 +66,7 @@ public class MockEmailAccess {
         return findMailOrFail(email, subject, TextSearchMode.EXACT, maxSecondsToWait);
     }
 
-    public MockEmailEntry findMailOrFail(String email, String subjectSearch, TextSearchMode subjectTestMode, int maxSecondsToWait) {
+    public MockEmailEntry findMailOrFail(String email, String subjectSearch, TextSearchMode subjectSearchMode, int maxSecondsToWait) {
         MockEmailEntry found = null;
         List<MockEmailEntry> list = null;
         for (int i = 0; i < maxSecondsToWait; i++) {
@@ -83,14 +83,14 @@ public class MockEmailAccess {
                     /* cannot be checked */
                     continue;
                 }
-                switch (subjectTestMode) {
+                switch (subjectSearchMode) {
                 case EXACT:
                     if (message.subject.equals(subjectSearch)) {
                         found = message;
                     }
                     break;
                 case CONTAINS:
-                    if (message.subject.indexOf(subjectSearch)!=-1) {
+                    if (message.subject.indexOf(subjectSearch) != -1) {
                         found = message;
                     }
                     break;
@@ -116,7 +116,21 @@ public class MockEmailAccess {
             StringBuilder sb = new StringBuilder();
             sb.append("Did not find a mail containing:\n-emailaddress (TO/CC/BCC): ");
             sb.append(email);
-            sb.append("\n-subject (regexp): '");
+            sb.append("\n-subject");
+            switch (subjectSearchMode) {
+            case CONTAINS:
+                sb.append("(contains)");
+                break;
+            case EXACT:
+                sb.append("(exact)");
+                break;
+            case REGLAR_EXPRESSON:
+                sb.append("(regexp)");
+                break;
+            default:
+                break;
+            }
+            sb.append(":'");
             sb.append(subjectSearch);
             sb.append("'\n\nFound mails for this email address:");
             for (MockEmailEntry message : list) {

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/MockEmailAccess.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/MockEmailAccess.java
@@ -94,7 +94,7 @@ public class MockEmailAccess {
                         found = message;
                     }
                     break;
-                case REGLAR_EXPRESSON:
+                case REGULAR_EXPRESSON:
                     if (message.subject.matches(subjectSearch)) {
                         found = message;
                     }
@@ -124,7 +124,7 @@ public class MockEmailAccess {
             case EXACT:
                 sb.append("(exact)");
                 break;
-            case REGLAR_EXPRESSON:
+            case REGULAR_EXPRESSON:
                 sb.append("(regexp)");
                 break;
             default:

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/TestJSONHelper.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/TestJSONHelper.java
@@ -93,5 +93,14 @@ public class TestJSONHelper {
             return json;
         }
     }
+    
+    
+    public <T> T createFromJSON(String json, Class<T> clazz) {
+        try {
+            return TestJSONHelper.get().getMapper().readValue(json.getBytes(), clazz);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot convert given JSON to clazz:"+clazz, e);
+        }
+    }
 
 }

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/TestJSONHelper.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/TestJSONHelper.java
@@ -93,13 +93,12 @@ public class TestJSONHelper {
             return json;
         }
     }
-    
-    
+
     public <T> T createFromJSON(String json, Class<T> clazz) {
         try {
             return TestJSONHelper.get().getMapper().readValue(json.getBytes(), clazz);
         } catch (IOException e) {
-            throw new IllegalStateException("Cannot convert given JSON to clazz:"+clazz, e);
+            throw new IllegalStateException("Cannot convert given JSON to clazz:" + clazz, e);
         }
     }
 

--- a/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario2/UserAdministrationScenario2IntTest.java
+++ b/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario2/UserAdministrationScenario2IntTest.java
@@ -38,7 +38,7 @@ public class UserAdministrationScenario2IntTest {
 			isInSuperAdminList();
 		/* test notifications */
 		assertUser(userBecomingAdmin).hasReceivedEmail("SecHub administrator privileges granted");
-		assertMailExists("int-test_superadmins_npm@example.org", "SecHub: Granted administrator rights.*" + userBecomingAdmin.getUserId(), TextSearchMode.REGLAR_EXPRESSON);
+		assertMailExists("int-test_superadmins_npm@example.org", "SecHub: Granted administrator rights.*" + userBecomingAdmin.getUserId(), TextSearchMode.REGULAR_EXPRESSON);
 	}
 	/* @formatter:on */
 
@@ -122,7 +122,7 @@ public class UserAdministrationScenario2IntTest {
 		/* test notifications */
 		assertUser(userNoMoreAdmin).hasReceivedEmail("SecHub administrator privileges revoked");
 		assertMailExists("int-test_superadmins_npm@example.org",
-				"SecHub: Revoked administrator rights.*" + userNoMoreAdmin.getUserId(), TextSearchMode.REGLAR_EXPRESSON);
+				"SecHub: Revoked administrator rights.*" + userNoMoreAdmin.getUserId(), TextSearchMode.REGULAR_EXPRESSON);
 	}
 	/* @formatter:on */
 

--- a/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario2/UserAdministrationScenario2IntTest.java
+++ b/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario2/UserAdministrationScenario2IntTest.java
@@ -68,10 +68,8 @@ public class UserAdministrationScenario2IntTest {
         assertEquals(newEmailAddress, updatedDetails.getEmail());
 
         // check mails have been sent
-        assertMailExists(formerEmailAddress, "A SecHub administrator has changed your email adress and it will not be used any longer for SecHub.",
-                TextSearchMode.CONTAINS);
-        assertMailExists(newEmailAddress, "A SecHub administrator has changed your email address from " + formerEmailAddress + " to " + newEmailAddress,
-                TextSearchMode.CONTAINS);
+        assertMailExists(newEmailAddress, "has been changed to this address", TextSearchMode.CONTAINS);
+        assertMailExists(formerEmailAddress, "SecHub account email address changed", TextSearchMode.CONTAINS);
     }
 
     @Test

--- a/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario3/ProjectAdministrationScenario3IntTest.java
+++ b/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario3/ProjectAdministrationScenario3IntTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.mercedesbenz.sechub.integrationtest.api.IntegrationTestSetup;
+import com.mercedesbenz.sechub.integrationtest.api.TextSearchMode;
 
 public class ProjectAdministrationScenario3IntTest {
 
@@ -82,8 +83,8 @@ public class ProjectAdministrationScenario3IntTest {
         assertUser(USER_3).isAssignedToProject(PROJECT_1);
         assertUser(USER_1).isNotOwnerOf(PROJECT_1);
 
-        assertUser(USER_3).hasReceivedEmail(subject, true);
-        assertUser(USER_2).hasReceivedEmail(subject, true);
-        assertUser(USER_1).hasReceivedEmail(subject, true);
+        assertUser(USER_3).hasReceivedEmail(subject, TextSearchMode.REGLAR_EXPRESSON);
+        assertUser(USER_2).hasReceivedEmail(subject, TextSearchMode.REGLAR_EXPRESSON);
+        assertUser(USER_1).hasReceivedEmail(subject, TextSearchMode.REGLAR_EXPRESSON);
     }
 }

--- a/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario3/ProjectAdministrationScenario3IntTest.java
+++ b/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario3/ProjectAdministrationScenario3IntTest.java
@@ -83,8 +83,8 @@ public class ProjectAdministrationScenario3IntTest {
         assertUser(USER_3).isAssignedToProject(PROJECT_1);
         assertUser(USER_1).isNotOwnerOf(PROJECT_1);
 
-        assertUser(USER_3).hasReceivedEmail(subject, TextSearchMode.REGLAR_EXPRESSON);
-        assertUser(USER_2).hasReceivedEmail(subject, TextSearchMode.REGLAR_EXPRESSON);
-        assertUser(USER_1).hasReceivedEmail(subject, TextSearchMode.REGLAR_EXPRESSON);
+        assertUser(USER_3).hasReceivedEmail(subject, TextSearchMode.REGULAR_EXPRESSON);
+        assertUser(USER_2).hasReceivedEmail(subject, TextSearchMode.REGULAR_EXPRESSON);
+        assertUser(USER_1).hasReceivedEmail(subject, TextSearchMode.REGULAR_EXPRESSON);
     }
 }

--- a/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandler.java
+++ b/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandler.java
@@ -27,6 +27,7 @@ import com.mercedesbenz.sechub.domain.notification.user.NewAPITokenAppliedUserNo
 import com.mercedesbenz.sechub.domain.notification.user.NewApiTokenRequestedUserNotificationService;
 import com.mercedesbenz.sechub.domain.notification.user.SignUpRequestedAdminNotificationService;
 import com.mercedesbenz.sechub.domain.notification.user.UserDeletedNotificationService;
+import com.mercedesbenz.sechub.domain.notification.user.UserEmailAddressChangedNotificationService;
 import com.mercedesbenz.sechub.sharedkernel.messaging.AsynchronMessageHandler;
 import com.mercedesbenz.sechub.sharedkernel.messaging.ClusterMemberMessage;
 import com.mercedesbenz.sechub.sharedkernel.messaging.DomainMessage;
@@ -44,6 +45,9 @@ public class NotificationMessageHandler implements AsynchronMessageHandler {
 
     @Autowired
     UserDeletedNotificationService userDeletedNotificationService;
+    
+    @Autowired
+    UserEmailAddressChangedNotificationService userEmailAddressChangedNotificationService;
 
     @Autowired
     NewAPITokenAppliedUserNotificationService newAPITokenAppliedUserNotificationService;
@@ -108,6 +112,7 @@ public class NotificationMessageHandler implements AsynchronMessageHandler {
     @Autowired
     InformAdminsThatNewSchedulerInstanceHasBeenStarted informAdminsThatNewSchedulerInstanceHasBeenStarted;
 
+  
     @Override
     public void receiveAsyncMessage(DomainMessage request) {
         MessageID messageId = request.getMessageId();
@@ -160,9 +165,18 @@ public class NotificationMessageHandler implements AsynchronMessageHandler {
         case PROJECT_OWNER_CHANGED:
             handleOwnerChanged(request.get(MessageDataKeys.PROJECT_OWNER_CHANGE_DATA), request.get(MessageDataKeys.ENVIRONMENT_BASE_URL));
             break;
+        case USER_EMAIL_ADDRESS_CHANGED:
+            handleUserEmailChanged(request.get(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA));
+            break;
+            
         default:
             throw new IllegalStateException("unhandled message id:" + messageId);
         }
+    }
+
+    @IsReceivingAsyncMessage(MessageID.USER_EMAIL_ADDRESS_CHANGED)
+    private void handleUserEmailChanged(UserMessage userMessage) {
+        userEmailAddressChangedNotificationService.notify(userMessage);
     }
 
     @IsReceivingAsyncMessage(MessageID.SCHEDULER_STARTED)

--- a/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandler.java
+++ b/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandler.java
@@ -45,7 +45,7 @@ public class NotificationMessageHandler implements AsynchronMessageHandler {
 
     @Autowired
     UserDeletedNotificationService userDeletedNotificationService;
-    
+
     @Autowired
     UserEmailAddressChangedNotificationService userEmailAddressChangedNotificationService;
 
@@ -112,7 +112,6 @@ public class NotificationMessageHandler implements AsynchronMessageHandler {
     @Autowired
     InformAdminsThatNewSchedulerInstanceHasBeenStarted informAdminsThatNewSchedulerInstanceHasBeenStarted;
 
-  
     @Override
     public void receiveAsyncMessage(DomainMessage request) {
         MessageID messageId = request.getMessageId();
@@ -168,7 +167,7 @@ public class NotificationMessageHandler implements AsynchronMessageHandler {
         case USER_EMAIL_ADDRESS_CHANGED:
             handleUserEmailChanged(request.get(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA));
             break;
-            
+
         default:
             throw new IllegalStateException("unhandled message id:" + messageId);
         }

--- a/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationService.java
+++ b/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationService.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+package com.mercedesbenz.sechub.domain.notification.user;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+
+import com.mercedesbenz.sechub.domain.notification.email.EmailService;
+import com.mercedesbenz.sechub.domain.notification.email.MailMessageFactory;
+import com.mercedesbenz.sechub.sharedkernel.Step;
+import com.mercedesbenz.sechub.sharedkernel.messaging.UserMessage;
+import com.mercedesbenz.sechub.sharedkernel.usecases.admin.user.UseCaseAdminUpdatesUserEmailAddress;
+
+@Service
+public class UserEmailAddressChangedNotificationService {
+
+    static final String EMAIL_SUBJECT_NEW_ADDRESS = "Your SecHub account has been changed to this address";
+    static final String EMAIL_SUBJECT_FORMER_ADDRESS = "SecHub account email address changed";
+
+    @Autowired
+    MailMessageFactory factory;
+
+    @Autowired
+    EmailService emailService;
+
+    @UseCaseAdminUpdatesUserEmailAddress(@Step(number = 3, next = { Step.NO_NEXT_STEP }, name = "Inform user that the email address has been changed"))
+    public void notify(UserMessage userMessage) {
+        sendEmailToFormerUserEmailAddress(userMessage);
+        sendEmailToNewUserEmailAddress(userMessage);
+
+    }
+
+    private void sendEmailToFormerUserEmailAddress(UserMessage userMessage) {
+        StringBuilder emailContent = new StringBuilder();
+        emailContent.append(createEmailStart(userMessage));
+        emailContent.append(" and it will not be used any longer for SecHub.\n\n"
+                + "In case you do not receive a follow up notification to the new email address, please inform your SecHub administrator!");
+
+        SimpleMailMessage message = factory.createMessage(EMAIL_SUBJECT_FORMER_ADDRESS);
+        message.setTo(userMessage.getFormerEmailAddress());
+        message.setText(emailContent.toString());
+
+        emailService.send(message);
+    }
+    
+    private void sendEmailToNewUserEmailAddress(UserMessage userMessage) {
+
+        StringBuilder emailContent = new StringBuilder();
+        emailContent.append(createEmailStart(userMessage));
+        emailContent.append(" from ");
+        emailContent.append(userMessage.getFormerEmailAddress());
+        emailContent.append(" to ");
+        emailContent.append(userMessage.getEmailAdress());
+        emailContent.append(". \nYour old email address is not used in SecHub any longer.");
+
+        SimpleMailMessage message = factory.createMessage(EMAIL_SUBJECT_NEW_ADDRESS);
+        message.setTo(userMessage.getEmailAdress());
+        message.setText(emailContent.toString());
+
+        emailService.send(message);
+    }
+
+    private String createEmailStart(UserMessage userMessage) {
+        // We userMessage.getSubject() to create the beginning of the subject.
+        // So we can use this notification service by different use cases. 
+        return userMessage.getSubject();
+    }
+
+}

--- a/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationService.java
+++ b/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationService.java
@@ -42,7 +42,7 @@ public class UserEmailAddressChangedNotificationService {
 
         emailService.send(message);
     }
-    
+
     private void sendEmailToNewUserEmailAddress(UserMessage userMessage) {
 
         StringBuilder emailContent = new StringBuilder();
@@ -62,7 +62,7 @@ public class UserEmailAddressChangedNotificationService {
 
     private String createEmailStart(UserMessage userMessage) {
         // We userMessage.getSubject() to create the beginning of the subject.
-        // So we can use this notification service by different use cases. 
+        // So we can use this notification service by different use cases.
         return userMessage.getSubject();
     }
 

--- a/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandlerTest.java
+++ b/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandlerTest.java
@@ -13,6 +13,7 @@ import com.mercedesbenz.sechub.domain.notification.user.NewAPITokenAppliedUserNo
 import com.mercedesbenz.sechub.domain.notification.user.NewApiTokenRequestedUserNotificationService;
 import com.mercedesbenz.sechub.domain.notification.user.SignUpRequestedAdminNotificationService;
 import com.mercedesbenz.sechub.domain.notification.user.UserDeletedNotificationService;
+import com.mercedesbenz.sechub.domain.notification.user.UserEmailAddressChangedNotificationService;
 import com.mercedesbenz.sechub.sharedkernel.messaging.DomainMessage;
 import com.mercedesbenz.sechub.sharedkernel.messaging.MessageDataKeys;
 import com.mercedesbenz.sechub.sharedkernel.messaging.MessageID;
@@ -29,7 +30,7 @@ public class NotificationMessageHandlerTest {
     private InformAdminsThatProjectHasBeenDeletedNotificationService mockedInformAdminsThatProjectHasBeenDeletedNotificationService;
     private InformOwnerThatProjectHasBeenDeletedNotificationService mockedInformOwnerThatProjectHasBeenDeletedNotificationService;
     private InformUsersThatProjectHasBeenDeletedNotificationService mockedInformUsersThatProjectHasBeenDeletedNotificationService;
-
+    private UserEmailAddressChangedNotificationService  mockedUserEmailAddressChangedNotificationService;
     @Before
     public void before() throws Exception {
         mockedSignUpRequestedAdminNotificationService = mock(SignUpRequestedAdminNotificationService.class);
@@ -39,13 +40,15 @@ public class NotificationMessageHandlerTest {
         mockedInformAdminsThatProjectHasBeenDeletedNotificationService = mock(InformAdminsThatProjectHasBeenDeletedNotificationService.class);
         mockedInformOwnerThatProjectHasBeenDeletedNotificationService = mock(InformOwnerThatProjectHasBeenDeletedNotificationService.class);
         mockedInformUsersThatProjectHasBeenDeletedNotificationService = mock(InformUsersThatProjectHasBeenDeletedNotificationService.class);
-
+        mockedUserEmailAddressChangedNotificationService = mock(UserEmailAddressChangedNotificationService.class);
+        
         handlerToTest = new NotificationMessageHandler();
         handlerToTest.signupRequestedAdminNotificationService = mockedSignUpRequestedAdminNotificationService;
         handlerToTest.newAPITokenAppliedUserNotificationService = mockedNewAPITokenAppliedUserNotificationService;
         handlerToTest.newApiTokenRequestedUserNotificationService = mockedNewApiTokenRequestedUserNotificationService;
         handlerToTest.userDeletedNotificationService = mockedUserDeletedNotificationService;
-
+        handlerToTest.userEmailAddressChangedNotificationService=mockedUserEmailAddressChangedNotificationService;
+        
         /* project deleted */
         handlerToTest.informAdminsThatProjectHasBeenDeletedService = mockedInformAdminsThatProjectHasBeenDeletedNotificationService;
         handlerToTest.informOwnerThatProjectHasBeenDeletedService = mockedInformOwnerThatProjectHasBeenDeletedNotificationService;
@@ -129,6 +132,21 @@ public class NotificationMessageHandlerTest {
 
         /* test */
         verify(mockedNewApiTokenRequestedUserNotificationService).notify(userMessage);
+    }
+    
+    @Test
+    public void an_event_about_email_updatedeleted_user_triggers_UserEmailAddressChangedNotificationService() {
+        /* prepare */
+        UserMessage userMessage = mock(UserMessage.class);
+        DomainMessage request = mock(DomainMessage.class);
+        when(request.getMessageId()).thenReturn(MessageID.USER_EMAIL_ADDRESS_CHANGED);
+        when(request.get(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA)).thenReturn(userMessage);
+
+        /* execute */
+        handlerToTest.receiveAsyncMessage(request);
+
+        /* test */
+        verify(mockedUserEmailAddressChangedNotificationService).notify(userMessage);
     }
 
 }

--- a/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandlerTest.java
+++ b/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/NotificationMessageHandlerTest.java
@@ -30,7 +30,8 @@ public class NotificationMessageHandlerTest {
     private InformAdminsThatProjectHasBeenDeletedNotificationService mockedInformAdminsThatProjectHasBeenDeletedNotificationService;
     private InformOwnerThatProjectHasBeenDeletedNotificationService mockedInformOwnerThatProjectHasBeenDeletedNotificationService;
     private InformUsersThatProjectHasBeenDeletedNotificationService mockedInformUsersThatProjectHasBeenDeletedNotificationService;
-    private UserEmailAddressChangedNotificationService  mockedUserEmailAddressChangedNotificationService;
+    private UserEmailAddressChangedNotificationService mockedUserEmailAddressChangedNotificationService;
+
     @Before
     public void before() throws Exception {
         mockedSignUpRequestedAdminNotificationService = mock(SignUpRequestedAdminNotificationService.class);
@@ -41,14 +42,14 @@ public class NotificationMessageHandlerTest {
         mockedInformOwnerThatProjectHasBeenDeletedNotificationService = mock(InformOwnerThatProjectHasBeenDeletedNotificationService.class);
         mockedInformUsersThatProjectHasBeenDeletedNotificationService = mock(InformUsersThatProjectHasBeenDeletedNotificationService.class);
         mockedUserEmailAddressChangedNotificationService = mock(UserEmailAddressChangedNotificationService.class);
-        
+
         handlerToTest = new NotificationMessageHandler();
         handlerToTest.signupRequestedAdminNotificationService = mockedSignUpRequestedAdminNotificationService;
         handlerToTest.newAPITokenAppliedUserNotificationService = mockedNewAPITokenAppliedUserNotificationService;
         handlerToTest.newApiTokenRequestedUserNotificationService = mockedNewApiTokenRequestedUserNotificationService;
         handlerToTest.userDeletedNotificationService = mockedUserDeletedNotificationService;
-        handlerToTest.userEmailAddressChangedNotificationService=mockedUserEmailAddressChangedNotificationService;
-        
+        handlerToTest.userEmailAddressChangedNotificationService = mockedUserEmailAddressChangedNotificationService;
+
         /* project deleted */
         handlerToTest.informAdminsThatProjectHasBeenDeletedService = mockedInformAdminsThatProjectHasBeenDeletedNotificationService;
         handlerToTest.informOwnerThatProjectHasBeenDeletedService = mockedInformOwnerThatProjectHasBeenDeletedNotificationService;
@@ -133,7 +134,7 @@ public class NotificationMessageHandlerTest {
         /* test */
         verify(mockedNewApiTokenRequestedUserNotificationService).notify(userMessage);
     }
-    
+
     @Test
     public void an_event_about_email_updatedeleted_user_triggers_UserEmailAddressChangedNotificationService() {
         /* prepare */

--- a/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationServiceTest.java
+++ b/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationServiceTest.java
@@ -1,0 +1,104 @@
+package com.mercedesbenz.sechub.domain.notification.user;
+
+import static com.mercedesbenz.sechub.domain.notification.user.UserEmailAddressChangedNotificationService.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mail.SimpleMailMessage;
+
+import com.mercedesbenz.sechub.domain.notification.email.EmailService;
+import com.mercedesbenz.sechub.domain.notification.email.MailMessageFactory;
+import com.mercedesbenz.sechub.sharedkernel.messaging.UserMessage;
+
+class UserEmailAddressChangedNotificationServiceTest {
+
+    private UserEmailAddressChangedNotificationService serviceToTest;
+    private MailMessageFactory mailMessageFactory;
+    private EmailService emailService;
+
+    @BeforeEach
+    void beforeEach() {
+        serviceToTest = new UserEmailAddressChangedNotificationService();
+        mailMessageFactory = mock(MailMessageFactory.class);
+        emailService = mock(EmailService.class);
+
+        serviceToTest.emailService = emailService;
+        serviceToTest.factory = mailMessageFactory;
+    }
+
+    @Test
+    void sends_emails_to_former_and_new_mail_address_containing_expected_content() {
+        /* prepare */
+        String emailAddress = "email.adress@example.org";
+        String formerEmailAddress = "former_email.adress@example.org";
+
+        UserMessage userMessage = new UserMessage();
+        userMessage.setEmailAdress(emailAddress);
+        userMessage.setFormerEmailAddress(formerEmailAddress);
+        userMessage.setSubject("Your mail adress has changed by a test");
+
+        SimpleMailMessage simpleMailmessageFormer = new SimpleMailMessage();
+        simpleMailmessageFormer.setSubject("<former>");
+
+        SimpleMailMessage simpleMailmessageNew = new SimpleMailMessage();
+        simpleMailmessageNew.setSubject("<new>");
+
+        when(mailMessageFactory.createMessage(EMAIL_SUBJECT_FORMER_ADDRESS)).thenReturn(simpleMailmessageFormer);
+        when(mailMessageFactory.createMessage(EMAIL_SUBJECT_NEW_ADDRESS)).thenReturn(simpleMailmessageNew);
+
+        /* execute */
+        serviceToTest.notify(userMessage);
+
+        /* test */
+        Mails mails = fetchSentMailsFromMockObjects(emailAddress, formerEmailAddress);
+        assertNotNull(mails.receivedNew);
+        assertNotNull(mails.receivedFormer);
+        assertNotSame(mails.receivedFormer, mails.receivedNew);
+
+        assertEquals("<former>", mails.receivedFormer.getSubject());
+        assertEquals("<new>", mails.receivedNew.getSubject());
+
+        /* @formatter:off */
+        String receivedFormerText = mails.receivedFormer.getText();
+        String receivedNewText = mails.receivedNew.getText();
+        
+        assertEquals("Your mail adress has changed by a test and it will not be used any longer for SecHub.\n"
+                + "\n"
+                + "In case you do not receive a follow up notification to the new email address, please inform your SecHub administrator!", 
+                receivedFormerText);
+        assertEquals("Your mail adress has changed by a test from former_email.adress@example.org to email.adress@example.org. \n"
+                + "Your old email address is not used in SecHub any longer.", 
+                receivedNewText);
+        /* @formatter:on */
+
+    }
+
+    private Mails fetchSentMailsFromMockObjects(String emailAdress, String formerEmailAdress) {
+        ArgumentCaptor<SimpleMailMessage> messageCaptor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(emailService, times(2)).send(messageCaptor.capture());
+        List<SimpleMailMessage> messagesSent = messageCaptor.getAllValues();
+
+        assertEquals(2, messagesSent.size());
+        Mails data = new Mails();
+        for (SimpleMailMessage message : messagesSent) {
+            if (emailAdress.equals(message.getTo()[0])) {
+                data.receivedNew = message;
+            }
+            if (formerEmailAdress.equals(message.getTo()[0])) {
+                data.receivedFormer = message;
+            }
+        }
+        return data;
+    }
+
+    private class Mails {
+        SimpleMailMessage receivedFormer;
+        SimpleMailMessage receivedNew;
+    }
+
+}

--- a/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationServiceTest.java
+++ b/sechub-notification/src/test/java/com/mercedesbenz/sechub/domain/notification/user/UserEmailAddressChangedNotificationServiceTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 package com.mercedesbenz.sechub.domain.notification.user;
 
 import static com.mercedesbenz.sechub.domain.notification.user.UserEmailAddressChangedNotificationService.*;
@@ -66,13 +67,13 @@ class UserEmailAddressChangedNotificationServiceTest {
         /* @formatter:off */
         String receivedFormerText = mails.receivedFormer.getText();
         String receivedNewText = mails.receivedNew.getText();
-        
+
         assertEquals("Your mail adress has changed by a test and it will not be used any longer for SecHub.\n"
                 + "\n"
-                + "In case you do not receive a follow up notification to the new email address, please inform your SecHub administrator!", 
+                + "In case you do not receive a follow up notification to the new email address, please inform your SecHub administrator!",
                 receivedFormerText);
         assertEquals("Your mail adress has changed by a test from former_email.adress@example.org to email.adress@example.org. \n"
-                + "Your old email address is not used in SecHub any longer.", 
+                + "Your old email address is not used in SecHub any longer.",
                 receivedNewText);
         /* @formatter:on */
 

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageDataKeys.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageDataKeys.java
@@ -125,7 +125,7 @@ public class MessageDataKeys {
      * Does contain former access level and new one
      */
     public static final MessageDataKey<ProjectMessage> PROJECT_ACCESS_LEVEL_CHANGE_DATA = createProjectMessageKey("project.accesslevel.change.data");
-    
+
     /**
      * Does contain userid, former email address, new email address
      */

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageDataKeys.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageDataKeys.java
@@ -125,6 +125,11 @@ public class MessageDataKeys {
      * Does contain former access level and new one
      */
     public static final MessageDataKey<ProjectMessage> PROJECT_ACCESS_LEVEL_CHANGE_DATA = createProjectMessageKey("project.accesslevel.change.data");
+    
+    /**
+     * Does contain userid, former email address, new email address
+     */
+    public static final MessageDataKey<UserMessage> USER_EMAIL_ADDRESS_CHANGE_DATA = createUserMessageKey("user.emailaddress.change.data");
 
     /* +-----------------------------------------------------------------------+ */
     /* +............................ Helpers ..................................+ */

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageID.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageID.java
@@ -146,9 +146,15 @@ public enum MessageID {
     PROJECT_OWNER_CHANGED(MessageDataKeys.PROJECT_OWNER_CHANGE_DATA, MessageDataKeys.ENVIRONMENT_BASE_URL),
 
     /**
-     * Inform the the access level for a project has been changed
+     * Inform that the access level for a project has been changed
      */
-    PROJECT_ACCESS_LEVEL_CHANGED(MessageDataKeys.PROJECT_ACCESS_LEVEL_CHANGE_DATA),;
+    PROJECT_ACCESS_LEVEL_CHANGED(MessageDataKeys.PROJECT_ACCESS_LEVEL_CHANGE_DATA),
+    
+    /**
+     * Inform that the email address of an user has been changed
+     */
+    USER_EMAIL_ADDRESS_CHANGED(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA),
+    ;
 
     private Set<MessageDataKey<?>> unmodifiableKeys;
 

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageID.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/MessageID.java
@@ -149,12 +149,11 @@ public enum MessageID {
      * Inform that the access level for a project has been changed
      */
     PROJECT_ACCESS_LEVEL_CHANGED(MessageDataKeys.PROJECT_ACCESS_LEVEL_CHANGE_DATA),
-    
+
     /**
      * Inform that the email address of an user has been changed
      */
-    USER_EMAIL_ADDRESS_CHANGED(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA),
-    ;
+    USER_EMAIL_ADDRESS_CHANGED(MessageDataKeys.USER_EMAIL_ADDRESS_CHANGE_DATA),;
 
     private Set<MessageDataKey<?>> unmodifiableKeys;
 

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/UserMessage.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/UserMessage.java
@@ -138,10 +138,10 @@ public class UserMessage implements JSONable<UserMessage> {
      * events when an email address has changed. The {@link #getEmailAdress()} shall
      * contain the new mail adress in this case.
      * 
-     * @param oldEmailAdress
+     * @param formerEmailAddress
      */
-    public void setFormerEmailAddress(String oldEmailAdress) {
-        this.formerEmailAddress = oldEmailAdress;
+    public void setFormerEmailAddress(String formerEmailAddress) {
+        this.formerEmailAddress = formerEmailAddress;
     }
 
 }

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/UserMessage.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/UserMessage.java
@@ -36,6 +36,8 @@ public class UserMessage implements JSONable<UserMessage> {
 
     private String subject;
 
+    private String formerEmailAddress;
+
     @Override
     public Class<UserMessage> getJSONTargetClass() {
         return UserMessage.class;
@@ -118,6 +120,28 @@ public class UserMessage implements JSONable<UserMessage> {
 
     public String getSubject() {
         return subject;
+    }
+
+    /**
+     * Returns the former email address of an user. This information is only
+     * available on events about email changes. All other events will have not this
+     * information.
+     * 
+     * @return former email address or <code>null</code>
+     */
+    public String getFormerEmailAddress() {
+        return formerEmailAddress;
+    }
+
+    /**
+     * Set the former email address of an user. Should only be called for user
+     * events when an email address has changed. The {@link #getEmailAdress()} shall
+     * contain the new mail adress in this case.
+     * 
+     * @param oldEmailAdress
+     */
+    public void setFormerEmailAddress(String oldEmailAdress) {
+        this.formerEmailAddress = oldEmailAdress;
     }
 
 }

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/UserMessage.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/messaging/UserMessage.java
@@ -126,7 +126,7 @@ public class UserMessage implements JSONable<UserMessage> {
      * Returns the former email address of an user. This information is only
      * available on events about email changes. All other events will have not this
      * information.
-     * 
+     *
      * @return former email address or <code>null</code>
      */
     public String getFormerEmailAddress() {
@@ -137,7 +137,7 @@ public class UserMessage implements JSONable<UserMessage> {
      * Set the former email address of an user. Should only be called for user
      * events when an email address has changed. The {@link #getEmailAdress()} shall
      * contain the new mail adress in this case.
-     * 
+     *
      * @param formerEmailAddress
      */
     public void setFormerEmailAddress(String formerEmailAddress) {

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/usecases/UseCaseIdentifier.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/usecases/UseCaseIdentifier.java
@@ -139,7 +139,10 @@ public enum UseCaseIdentifier {
 
     UC_ADMIN_CHANGES_PROJECT_DESCRIPTION(61),
 
-    UC_ADMIN_CHANGES_PROJECT_ACCESS_LEVEL(62),;
+    UC_ADMIN_CHANGES_PROJECT_ACCESS_LEVEL(62),
+    
+    UC_ADMIN_UPDATES_USER_EMAIL_ADDRESS(63),
+    ;
 
     /* +-----------------------------------------------------------------------+ */
     /* +............................ Helpers ................................+ */

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/usecases/UseCaseIdentifier.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/usecases/UseCaseIdentifier.java
@@ -140,9 +140,8 @@ public enum UseCaseIdentifier {
     UC_ADMIN_CHANGES_PROJECT_DESCRIPTION(61),
 
     UC_ADMIN_CHANGES_PROJECT_ACCESS_LEVEL(62),
-    
-    UC_ADMIN_UPDATES_USER_EMAIL_ADDRESS(63),
-    ;
+
+    UC_ADMIN_UPDATES_USER_EMAIL_ADDRESS(63),;
 
     /* +-----------------------------------------------------------------------+ */
     /* +............................ Helpers ................................+ */

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/usecases/admin/user/UseCaseAdminUpdatesUserEmailAddress.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/usecases/admin/user/UseCaseAdminUpdatesUserEmailAddress.java
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+package com.mercedesbenz.sechub.sharedkernel.usecases.admin.user;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.mercedesbenz.sechub.sharedkernel.Step;
+import com.mercedesbenz.sechub.sharedkernel.usecases.UseCaseDefinition;
+import com.mercedesbenz.sechub.sharedkernel.usecases.UseCaseGroup;
+import com.mercedesbenz.sechub.sharedkernel.usecases.UseCaseIdentifier;
+
+@Target(ElementType.METHOD)
+/* @formatter:off */
+@Retention(RetentionPolicy.RUNTIME)
+@UseCaseDefinition(
+		id=UseCaseIdentifier.UC_ADMIN_UPDATES_USER_EMAIL_ADDRESS,
+		group=UseCaseGroup.USER_ADMINISTRATION,
+		apiName="adminUpdatesUserEmailAddress",
+		title="Admin updates user email address",
+		description="admin/updateUserEmailAddress.adoc")
+public @interface UseCaseAdminUpdatesUserEmailAddress {
+
+	Step value();
+}
+/* @formatter:on */

--- a/sechub-testframework/src/main/java/com/mercedesbenz/sechub/test/TestCanaryException.java
+++ b/sechub-testframework/src/main/java/com/mercedesbenz/sechub/test/TestCanaryException.java
@@ -1,9 +1,10 @@
+// SPDX-License-Identifier: MIT
 package com.mercedesbenz.sechub.test;
 
 /**
  * A special runtime exception which is only used inside tests to simulate and
  * test exception handling.
- * 
+ *
  * @author Albert Tregnaghi
  *
  */

--- a/sechub-testframework/src/main/java/com/mercedesbenz/sechub/test/TestCanaryException.java
+++ b/sechub-testframework/src/main/java/com/mercedesbenz/sechub/test/TestCanaryException.java
@@ -1,0 +1,14 @@
+package com.mercedesbenz.sechub.test;
+
+/**
+ * A special runtime exception which is only used inside tests to simulate and
+ * test exception handling.
+ * 
+ * @author Albert Tregnaghi
+ *
+ */
+public class TestCanaryException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/sechub-testframework/src/main/java/com/mercedesbenz/sechub/test/TestURLBuilder.java
+++ b/sechub-testframework/src/main/java/com/mercedesbenz/sechub/test/TestURLBuilder.java
@@ -234,7 +234,6 @@ public class TestURLBuilder {
     public String buildUserFetchesFalsePositiveConfigurationOfProject(String projectId) {
         return buildUrl(API_PROJECT, projectId, "false-positives");
     }
-
     /* +-----------------------------------------------------------------------+ */
     /* +............................ anonymous ................................+ */
     /* +-----------------------------------------------------------------------+ */
@@ -293,6 +292,10 @@ public class TestURLBuilder {
 
     public String buildAdminShowsUserDetailsUrl(String userId) {
         return buildUrl(API_ADMIN_USER, userId);
+    }
+
+    public String buildAdminChangesUserEmailAddress(String userId, String newEmailAddress) {
+        return buildUrl(API_ADMIN_USER, userId, "email", newEmailAddress);
     }
 
     /* +-----------------------------------------------------------------------+ */


### PR DESCRIPTION
This PR
- closes #633 

This PR is now mentioned as an example in our wiki:   
https://github.com/mercedes-benz/sechub/wiki/FAQ#is-there-a-good-example-issue-for-new-contributors

Each commit contains detailed messages about a specific work done at the commit.
The feature (#633) itself seams to be very easy to implement (at a first glance..), but implementation handled much aspects from SecHub internals:

- introduce a complete new usecase, together with documentation parts
- introduce a main logic for the feature (REST controller, gets a new method,  we create a new Service)
- automated REST documentation by dedicated *RestDocTest 
- new integration tests
- new unit tests
- domain messaging (domain `administration` sends an event which is handled by `notification` domain)
- notification implementation
- extending the internal used testing framework
- adding a simple  DAUI action to have the new feature inside the developer administration UI

Details about architecture aspects are described at  https://mercedes-benz.github.io/sechub/latest/sechub-architecture.html
For some specific technical details please read https://mercedes-benz.github.io/sechub/latest/sechub-techdoc.html
