### PR TITLE
Fix cli help text example json format

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/help.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/help.go
@@ -50,7 +50,7 @@ Example 'sechub.json' config file which will configure a code scan and also a we
     "project": "my_project",
     "codeScan": {
       "fileSystem": { "folders": ["src-server/", "src-client/"] }
-    }
+    },
     "webScan"  : {
       "uris": ["https://www.myproject"]
     }


### PR DESCRIPTION
When using the cli for the first time, we copied the sample configuration from the help text into a new file.
Appearently, the json is not valid as it is presented in the help text as there is a missing comma.