### PR TITLE
Feature 929 custom output file path

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
@@ -25,7 +25,9 @@ type Config struct {
 	file                  string
 	ignoreDefaultExcludes bool
 	keepTempFiles         bool
+	outputFileName        string
 	outputFolder          string
+	outputLocation        string
 	projectID             string
 	quiet                 bool
 	reportFormat          string
@@ -79,8 +81,8 @@ func prepareOptionsFromCommandline(config *Config) {
 		helpOption, false, "Shows help and terminates")
 	flag.StringVar(&config.secHubJobUUID,
 		jobUUIDOption, "", "SecHub job uuid - Mandatory for actions '"+getStatusAction+"' or '"+getReportAction+"'")
-	flag.StringVar(&config.outputFolder,
-		outputOption, ".", "Output folder for reports etc.")
+	flag.StringVar(&config.outputLocation,
+		outputOption, "", "Where to place reports, false-positive files etc. Can be a directory, a file name or a file path. (Defaults to current directory)")
 	flag.StringVar(&config.projectID,
 		projectOption, config.projectID, "SecHub project id - Mandatory, but can also be defined in environment variable "+SechubProjectEnvVar+" or in config file")
 	flag.BoolVar(&config.quiet,
@@ -177,9 +179,9 @@ func NewConfigByFlags() *Config {
 	return &configFromInit
 }
 
-func assertValidConfig(configPtr *Config) {
-	if configPtr.trustAll {
-		if !configPtr.quiet {
+func assertValidConfig(config *Config) {
+	if config.trustAll {
+		if !config.quiet {
 			sechubUtil.LogWarning("Configured to trust all - means unknown service certificate is accepted. Don't use this in production!")
 		}
 	}
@@ -205,39 +207,42 @@ func assertValidConfig(configPtr *Config) {
 	 * 					Validation
 	 * --------------------------------------------------
 	 */
-	if configPtr.action == "" {
+	if config.action == "" {
 		sechubUtil.LogError("sechub action not set")
 		showHelpHint()
 		os.Exit(ExitCodeMissingParameter)
 	}
 
 	errorsFound := false
-	if mandatoryFields, ok := checklist[configPtr.action]; ok {
+	if mandatoryFields, ok := checklist[config.action]; ok {
 		for _, fieldname := range mandatoryFields {
-			if !isConfigFieldFilled(configPtr, fieldname) {
+			if !isConfigFieldFilled(config, fieldname) {
 				errorsFound = true
 			}
 		}
 	} else {
-		sechubUtil.LogError("Unknown action: '" + configPtr.action + "'")
+		sechubUtil.LogError("Unknown action: '" + config.action + "'")
 		errorsFound = true
 	}
 
-	if configPtr.action == interactiveMarkFalsePositivesAction && configPtr.file == "" {
+	if config.action == interactiveMarkFalsePositivesAction && config.file == "" {
 		// Let's try to find the latest report and take this as file
-		configPtr.file = sechubUtil.FindNewestMatchingFileInDir("sechub_report_.+\\.json$", configPtr.outputFolder)
-		if configPtr.file == "" {
+		config.file = sechubUtil.FindNewestMatchingFileInDir("sechub_report_.+\\.json$", config.outputLocation)
+		if config.file == "" {
 			sechubUtil.LogError("Input file is needed for action '" + interactiveMarkFalsePositivesAction + "'. Please define input file with -file option.")
 			errorsFound = true
 		} else {
-			fmt.Printf("Using latest report file %q.\n", configPtr.file)
+			fmt.Printf("Using latest report file %q.\n", config.file)
 		}
 	}
 
-	if !validateRequestedReportFormat(configPtr) {
+	if !validateRequestedReportFormat(config) {
 		errorsFound = true
 	}
-	if !validateTempDir(configPtr) {
+	if !validateTempDir(config) {
+		errorsFound = true
+	}
+	if !validateOutputLocation(config) {
 		errorsFound = true
 	}
 
@@ -247,10 +252,10 @@ func assertValidConfig(configPtr *Config) {
 	}
 
 	// For convenience: lowercase user id and project id if needed
-	configPtr.user = lowercaseOrNotice(configPtr.user, "user id")
-	configPtr.projectID = lowercaseOrNotice(configPtr.projectID, "project id")
+	config.user = lowercaseOrNotice(config.user, "user id")
+	config.projectID = lowercaseOrNotice(config.projectID, "project id")
 	// Remove trailing slash from url if present
-	configPtr.server = strings.TrimSuffix(configPtr.server, "/")
+	config.server = strings.TrimSuffix(config.server, "/")
 }
 
 // isConfigFieldFilled checks if field is not empty or is 'true' in case of boolean type
@@ -329,5 +334,10 @@ func validateTempDir(config *Config) bool {
 	}
 
 	config.tempDir = tempDirAbsolute
+	return true
+}
+
+// validateOutputLocation - Check given output location and fill config.outputFolder and config.outputFileName accordingly
+func validateOutputLocation(config *Config) bool {
 	return true
 }

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
@@ -223,3 +223,129 @@ func Test_validateTempDir(t *testing.T) {
 	sechubTestUtil.AssertTrue(result3, t)
 	sechubTestUtil.AssertFalse(result4, t)
 }
+
+func Test_validateOutputLocation_current_dir(t *testing.T) {
+	// PREPARE
+	var config Config
+	config.outputLocation = "."
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertTrue(result, t)
+	sechubTestUtil.AssertEquals(".", config.outputFolder, t)
+	sechubTestUtil.AssertEquals("", config.outputFileName, t)
+}
+
+func Test_validateOutputLocation_relative_dir(t *testing.T) {
+	// PREPARE
+	tempDir := "Test_validateOutputLocation_relative_dir"
+	sechubTestUtil.CreateTestDirectory(tempDir, 0755, t)
+	defer os.RemoveAll(tempDir)
+
+	var config Config
+	config.outputLocation = tempDir
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertTrue(result, t)
+	sechubTestUtil.AssertStringContains(config.outputFolder, tempDir, t)
+	sechubTestUtil.AssertEquals("", config.outputFileName, t)
+}
+
+func Test_validateOutputLocation_absolute_dir(t *testing.T) {
+	// PREPARE
+	tempDir := sechubTestUtil.InitializeTestTempDir(t)
+	sechubTestUtil.CreateTestDirectory(tempDir, 0755, t)
+	defer os.RemoveAll(tempDir)
+
+	var config Config
+	config.outputLocation = tempDir
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertTrue(result, t)
+	sechubTestUtil.AssertStringContains(config.outputFolder, tempDir, t)
+	sechubTestUtil.AssertEquals("", config.outputFileName, t)
+}
+
+func Test_validateOutputLocation_non_existing_dir(t *testing.T) {
+	// PREPARE
+	tempDir := "/this/really/does/not/exist"
+	var config Config
+	config.outputLocation = tempDir
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertFalse(result, t)
+}
+
+func Test_validateOutputLocation_absolute_filepath(t *testing.T) {
+	// PREPARE
+	tempFile := "testfile.json"
+	tempDir := sechubTestUtil.InitializeTestTempDir(t)
+	sechubTestUtil.CreateTestDirectory(tempDir, 0755, t)
+	defer os.RemoveAll(tempDir)
+
+	var config Config
+	config.outputLocation = filepath.Join(tempDir, tempFile)
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertTrue(result, t)
+	sechubTestUtil.AssertEquals(tempDir, config.outputFolder, t)
+	sechubTestUtil.AssertEquals(tempFile, config.outputFileName, t)
+}
+
+func Test_validateOutputLocation_invalid_filepath(t *testing.T) {
+	// PREPARE
+	tempFile := "testfile.json"
+	tempDir := "/this/really/does/not/exist"
+
+	var config Config
+	config.outputLocation = filepath.Join(tempDir, tempFile)
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertFalse(result, t)
+}
+
+func Test_validateOutputLocation_filename_only(t *testing.T) {
+	// PREPARE
+	tempFile := "Test_validateOutputLocation_filename_only.json"
+
+	var config Config
+	config.outputLocation = tempFile
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertTrue(result, t)
+	sechubTestUtil.AssertEquals(".", config.outputFolder, t)
+	sechubTestUtil.AssertEquals(tempFile, config.outputFileName, t)
+}
+
+func Test_validateOutputLocation_empty(t *testing.T) {
+	// PREPARE
+	var config Config
+
+	// EXECUTE
+	result := validateOutputLocation(&config)
+
+	// TEST
+	sechubTestUtil.AssertTrue(result, t)
+	sechubTestUtil.AssertEquals(".", config.outputFolder, t)
+	sechubTestUtil.AssertEquals("", config.outputFileName, t)
+}

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/controller.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/controller.go
@@ -139,15 +139,22 @@ func downloadSechubReport(context *Context) {
 		os.Exit(ExitCodeFailed)
 	}
 
-	// Example:  sechub_report_myproject_cdde8927-2df4-461c-b775-2dec9497e8b1.json
-	fileName := "sechub_report_" + context.config.projectID + "_" + context.config.secHubJobUUID + "." + context.config.reportFormat
+	fileName := context.config.outputFileName
+	if fileName == "" {
+		// Example:  sechub_report_myproject_cdde8927-2df4-461c-b775-2dec9497e8b1.json
+		fileName = "sechub_report_" + context.config.projectID + "_" + context.config.secHubJobUUID + "." + context.config.reportFormat
+	}
 
 	report := ReportDownload{serverResult: getSecHubJobReport(context), outputFolder: context.config.outputFolder, outputFileName: fileName}
 	report.save(context)
 }
 
 func downloadFalsePositivesList(context *Context) {
-	fileName := "sechub-false-positives-" + context.config.projectID + ".json"
+	fileName := context.config.outputFileName
+	if fileName == "" {
+		// Example: sechub-false-positives-myproject.json
+		fileName = "sechub-false-positives-" + context.config.projectID + ".json"
+	}
 
 	list := FalsePositivesList{serverResult: getFalsePositivesList(context), outputFolder: context.config.outputFolder, outputFileName: fileName}
 	list.save(context)

--- a/sechub-cli/src/mercedes-benz.com/sechub/testutil/asserts.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/testutil/asserts.go
@@ -79,14 +79,14 @@ func AssertJSONEquals(expected string, given string, t *testing.T) {
 // AssertEquals checks expected value equals given value (any type possible like string, int, ...)
 func AssertEquals(expected interface{}, given interface{}, t *testing.T) {
 	if expected != given {
-		t.Fatalf("Values differ:\n  Expected: %#v (type %T)\n  Got     : %#v (type %T)\n", expected, expected, given, given)
+		t.Fatalf("Values differ:\n   got: %#v (type %T)\n  want: %#v (type %T)\n", given, given, expected, expected)
 	}
 }
 
 // AssertNotEquals checks notExpected value equals given value
 func AssertNotEquals(notExpected interface{}, given interface{}, t *testing.T) {
 	if notExpected == given {
-		t.Fatalf("Values do NOT differ:\n  Unexpected: %#v (type %T)\n  Got       : %#v (type %T)\n", notExpected, notExpected, given, given)
+		t.Fatalf("Values do NOT differ:\n  got     : %#v (type %T)\n  unwanted: %#v (type %T)\n", given, given, notExpected, notExpected)
 	}
 }
 
@@ -149,4 +149,18 @@ func AssertMinimalFileSize(filePath string, size int64, t *testing.T) {
 		t.Fatalf("File %q too small: expected >= %d bytes, but has only %d.", filePath, size, fileinfo.Size())
 	}
 	Check(err, t)
+}
+
+// AssertContains checks wanted string is contained in given string s
+func AssertStringContains(s string, wanted string, t *testing.T) {
+	if !strings.Contains(s, wanted) {
+		t.Fatalf("Did not find \"%s\" inside \"%s\"", wanted, s)
+	}
+}
+
+// AssertStringContainsNot checks unwanted string is not contained in given string s
+func AssertStringContainsNot(s string, unwanted string, t *testing.T) {
+	if strings.Contains(s, unwanted) {
+		t.Fatalf("Found \"%s\" inside \"%s\", but should not be found.", unwanted, s)
+	}
 }

--- a/sechub-cli/src/mercedes-benz.com/sechub/util/fileHelpers.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/util/fileHelpers.go
@@ -70,3 +70,16 @@ func FindNewestMatchingFileInDir(filePattern string, dir string) string {
 	}
 	return newestFile
 }
+
+// VerifyDirectoryExists - verify that directory exists on the file system
+func VerifyDirectoryExists(directory string) bool {
+	fileinfo, err := os.Stat(directory)
+	if os.IsNotExist(err) {
+		return false
+	}
+	if !fileinfo.IsDir() {
+		return false
+	}
+
+	return true
+}

--- a/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
@@ -230,7 +230,7 @@ In below table, there is an overview of what can be defined where.
 | file | -file ||
 | job uuid | -jobUUID ||
 | network timeout | -timeout||
-| output folder | -output ||
+| output folder or file | -output ||
 | poll interval | -wait | SECHUB_WAITTIME_DEFAULT |
 | project id | -project | SECHUB_PROJECT |project
 | quiet mode | -quiet | SECHUB_QUIET |
@@ -274,8 +274,8 @@ Here is an overview of mandatory parameter for each `action`:
   Shows help and terminates
 - `-jobUUID <string>` +
   `{sechub}` job uuid (mandatory when using 'getStatus' or 'getReport')
-- `-output <path to folder>` +
-  Output folder for reports etc. (defaults to current working directory)
+- `-output <path to folder or file>` +
+  Where to place reports, false-positive files etc. Can be a directory, a file name or a file path (defaults to current working directory and default file names)
 - `-project <string>` +
   Unique project id - mandatory, but can also be defined in config file or via environment variable.
 - `-quiet` +


### PR DESCRIPTION
`-output` accepts now a directory, a file name or a file path
and is still backward compatible.

closes #929 