### PR TITLE
Feature 1132 client contentlength header

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/controller-uploadsourcezip.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/controller-uploadsourcezip.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	sechubUtil "mercedes-benz.com/sechub/util"
@@ -26,6 +27,8 @@ func uploadSourceZipFile(context *Context) {
 
 	request, err := newFileUploadRequestViaPipe(buildUploadSourceCodeAPICall(context), extraParams, "file", context.sourceZipFileName)
 	sechubUtil.HandleError(err, ExitCodeIOError)
+	sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("Sending %v:%v", request.Method, request.URL))
+	sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("Content length of upload request: %d bytes", request.ContentLength))
 
 	request.SetBasicAuth(context.config.user, context.config.apiToken)
 

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
@@ -106,6 +106,84 @@ func newFileUploadRequestViaPipe(uploadToURL string, params map[string]string, p
 
 	request, err := http.NewRequest("POST", uploadToURL, r)
 	request.Header.Set("Content-Type", m.FormDataContentType())
+	// request.Header.Set("Content-Length", "1641")
+	// fmt.Println(request.Header)
+
+	// Set HTTP protocol 1.1 and ContentLength to -1 will create a `transfer-encoding: chunked`.
+	// This avoids warnings about missing content length on server side.
+	// request.ContentLength = -1
+
+	request.ContentLength = computeContentLengthOfFileUpload(params, paramName, zipfilename)
+	fmt.Printf("Computed Content-Length = %d\n", request.ContentLength)
+
+	buf := make([]byte, 1)
+	summe := 0
+
+	for err == nil {
+		_, err = io.ReadAtLeast(r, buf, 1)
+		if err == io.EOF {
+			break
+		}
+		// fmt.Print(numberOfBytes)
+		// fmt.Print(" gelesen. Zeichen =")
+		// fmt.Println(string(buf))
+		summe++
+	}
+	fmt.Printf("    Real Content-Length = %d\n", summe)
+	// TODO: Write a test to check if computed size equals real stream size
 
 	return request, err
+}
+
+func computeContentLengthOfFileUpload(params map[string]string, paramName, zipfilename string) (contentLength int64) {
+	/* Real world example of multipart content sent to SecHub server when uploading:
+	--f76dd0c1a814e0af2f4d197827fd9caa1e9636276e064454356141ae1347
+	Content-Disposition: form-data; name="title"
+
+	Sourcecode zipped
+	--f76dd0c1a814e0af2f4d197827fd9caa1e9636276e064454356141ae1347
+	Content-Disposition: form-data; name="author"
+
+	Sechub client 0.0.0-285d1b6-dirty-20220324161639
+	--f76dd0c1a814e0af2f4d197827fd9caa1e9636276e064454356141ae1347
+	Content-Disposition: form-data; name="checkSum"
+
+	ccdcf7c07a8461f8aeb44f6bbd2166d184c79f7acfd86cb3415dcb452f274a63
+	--f76dd0c1a814e0af2f4d197827fd9caa1e9636276e064454356141ae1347
+	Content-Disposition: form-data; name="file"; filename="sourcecode-testproject.zip"
+	Content-Type: application/octet-stream
+
+	<binary content of zip file here>
+	--f76dd0c1a814e0af2f4d197827fd9caa1e9636276e064454356141ae1347--
+	*/
+	const ContentLengthMultipartBoundary = 63                                             // multipart boundary line including \n
+	const ContentLengthMultipartBoundaryTrailingLine = ContentLengthMultipartBoundary + 2 // multipart boundary line plus `--`
+
+	const ContentLengthFormData = 42 // Content-Disposition: form-data; name="..."  (including \n)
+
+	const ContentLengthFormDataZipFile = 92
+	// Content-Disposition: form-data; name="file"; filename="sourcecode.zip"
+	// Content-Type: application/octet-stream
+	// (including multiple \n)
+
+	contentLength = 0
+	for key, val := range params {
+		contentLength += ContentLengthMultipartBoundary
+		contentLength += ContentLengthFormData
+		contentLength += int64(len(key))
+		contentLength += int64(len(val))
+	}
+
+	// uploaded .zip file part
+	contentLength += ContentLengthMultipartBoundary
+	contentLength += ContentLengthFormDataZipFile
+	contentLength += int64(len(paramName))
+	contentLength += int64(len(filepath.Base(zipfilename)))
+
+	// TODO: read size of zip file from disk (util/filehelpers?)
+
+	// multipart trailing line
+	contentLength += ContentLengthMultipartBoundaryTrailingLine
+
+	return contentLength
 }

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
@@ -132,17 +132,18 @@ func computeContentLengthOfFileUpload(params map[string]string, paramName, zipfi
 	<binary content of zip file here>
 	--f76dd0c1a814e0af2f4d197827fd9caa1e9636276e064454356141ae1347--
 	*/
-	const ContentLengthMultipartBoundary = 63                                             // multipart boundary line including \n
+	const ContentLengthMultipartBoundary = 63                                             // multipart boundary line including newlines
 	const ContentLengthMultipartBoundaryTrailingLine = ContentLengthMultipartBoundary + 2 // multipart boundary line plus `--`
 
-	const ContentLengthFormData = 46 // Content-Disposition: form-data; name="..."  (including \n)
+	const ContentLengthFormData = 46 // Content-Disposition: form-data; name="..."  (including newlines)
 
 	const ContentLengthFormDataZipFile = 100
 	// Content-Disposition: form-data; name="file"; filename="sourcecode.zip"
 	// Content-Type: application/octet-stream
-	// (including multiple \n)
+	// (including newlines)
 
 	contentLength = 0
+	// multipart form-data parameter list
 	for key, val := range params {
 		contentLength += ContentLengthMultipartBoundary
 		contentLength += ContentLengthFormData
@@ -150,14 +151,12 @@ func computeContentLengthOfFileUpload(params map[string]string, paramName, zipfi
 		contentLength += int64(len(val))
 	}
 
-	// uploaded .zip file part
+	// multipart .zip file part
 	contentLength += ContentLengthMultipartBoundary
 	contentLength += ContentLengthFormDataZipFile
 	contentLength += int64(len(paramName))
 	contentLength += int64(len(filepath.Base(zipfilename)))
 	contentLength += sechubUtil.GetFileSize(zipfilename)
-
-	// TODO: read size of zip file from disk (util/filehelpers?)
 
 	// multipart trailing line
 	contentLength += ContentLengthMultipartBoundaryTrailingLine

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
@@ -106,31 +106,7 @@ func newFileUploadRequestViaPipe(uploadToURL string, params map[string]string, p
 
 	request, err := http.NewRequest("POST", uploadToURL, r)
 	request.Header.Set("Content-Type", m.FormDataContentType())
-	// request.Header.Set("Content-Length", "1641")
-	// fmt.Println(request.Header)
-
-	// Set HTTP protocol 1.1 and ContentLength to -1 will create a `transfer-encoding: chunked`.
-	// This avoids warnings about missing content length on server side.
-	// request.ContentLength = -1
-
 	request.ContentLength = computeContentLengthOfFileUpload(params, paramName, zipfilename)
-	fmt.Printf("Computed Content-Length = %d\n", request.ContentLength)
-
-	buf := make([]byte, 1)
-	summe := 0
-
-	for err == nil {
-		_, err = io.ReadAtLeast(r, buf, 1)
-		if err == io.EOF {
-			break
-		}
-		// fmt.Print(numberOfBytes)
-		// fmt.Print(" gelesen. Zeichen =")
-		// fmt.Println(string(buf))
-		summe++
-	}
-	fmt.Printf("    Real Content-Length = %d\n", summe)
-	// TODO: Write a test to check if computed size equals real stream size
 
 	return request, err
 }
@@ -159,9 +135,9 @@ func computeContentLengthOfFileUpload(params map[string]string, paramName, zipfi
 	const ContentLengthMultipartBoundary = 63                                             // multipart boundary line including \n
 	const ContentLengthMultipartBoundaryTrailingLine = ContentLengthMultipartBoundary + 2 // multipart boundary line plus `--`
 
-	const ContentLengthFormData = 42 // Content-Disposition: form-data; name="..."  (including \n)
+	const ContentLengthFormData = 46 // Content-Disposition: form-data; name="..."  (including \n)
 
-	const ContentLengthFormDataZipFile = 92
+	const ContentLengthFormDataZipFile = 100
 	// Content-Disposition: form-data; name="file"; filename="sourcecode.zip"
 	// Content-Type: application/octet-stream
 	// (including multiple \n)
@@ -179,6 +155,7 @@ func computeContentLengthOfFileUpload(params map[string]string, paramName, zipfi
 	contentLength += ContentLengthFormDataZipFile
 	contentLength += int64(len(paramName))
 	contentLength += int64(len(filepath.Base(zipfilename)))
+	contentLength += sechubUtil.GetFileSize(zipfilename)
 
 	// TODO: read size of zip file from disk (util/filehelpers?)
 

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	sechubTestUtil "mercedes-benz.com/sechub/testutil"
+)
+
+func Test_computeContentLengthOfFileUpload(t *testing.T) {
+	// PREPRARE
+	context := new(Context)
+	config := new(Config)
+	context.config = config
+
+	extraParams := map[string]string{
+		"title":    "Sourcecode zipped",
+		"author":   "Sechub client " + Version(),
+		"checkSum": context.sourceZipFileChecksum,
+	}
+
+	dir := sechubTestUtil.InitializeTestTempDir(t)
+	testfile := dir + "/testfile.zip"
+	defer os.RemoveAll(dir)
+	content := []byte("This is a fake zip file.\n")
+	sechubTestUtil.CreateTestFile(testfile, 0644, content, t)
+
+	// EXECUTE
+	request, _ := newFileUploadRequestViaPipe(buildUploadSourceCodeAPICall(context), extraParams, "file", testfile)
+	realContentLength := sechubTestUtil.CountBytesInStream(request.Body)
+	// TEST
+	fmt.Printf("Real content length: %d bytes\n", realContentLength)
+	fmt.Printf("Computed content length: %d bytes\n", request.ContentLength)
+	sechubTestUtil.AssertEquals(realContentLength, request.ContentLength, t)
+}

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper_test.go
@@ -31,6 +31,7 @@ func Test_computeContentLengthOfFileUpload(t *testing.T) {
 	// EXECUTE
 	request, _ := newFileUploadRequestViaPipe(buildUploadSourceCodeAPICall(context), extraParams, "file", testfile)
 	realContentLength := sechubTestUtil.CountBytesInStream(request.Body)
+
 	// TEST
 	fmt.Printf("Real content length: %d bytes\n", realContentLength)
 	fmt.Printf("Computed content length: %d bytes\n", request.ContentLength)

--- a/sechub-cli/src/mercedes-benz.com/sechub/testutil/ioTestHelpers.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/testutil/ioTestHelpers.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"io"
+)
+
+// CountBytesInStream - Return number of bytes in input. Reads until EOF.
+func CountBytesInStream(input io.ReadCloser) int64 {
+	buf, _ := io.ReadAll(input)
+	return int64(len(buf))
+}

--- a/sechub-cli/src/mercedes-benz.com/sechub/util/fileHelpers.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/util/fileHelpers.go
@@ -83,3 +83,11 @@ func VerifyDirectoryExists(directory string) bool {
 
 	return true
 }
+
+// FindNewestMatchingFileInDir - used e.g. for finding the latest report file
+func GetFileSize(filepath string) int64 {
+	fileinfo, err := os.Stat(filepath)
+	HandleIOError(err)
+
+	return fileinfo.Size()
+}


### PR DESCRIPTION
Client now sends content-length header also when uploading.

closes #1132 