### PR TITLE
Introduce SECHUB_DEBUG_HTTP #1168

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	configFilePath        string
 	configFileRead        bool
 	debug                 bool
+	debugHTTP             bool
 	file                  string
 	ignoreDefaultExcludes bool
 	keepTempFiles         bool
@@ -110,6 +111,8 @@ func parseConfigFromEnvironment(config *Config) {
 		os.Getenv(SechubApitokenEnvVar)
 	config.debug =
 		os.Getenv(SechubDebugEnvVar) == "true"
+	config.debugHTTP =
+		os.Getenv(SechubDebugHTTPEnvVar) == "true"
 	config.ignoreDefaultExcludes =
 		os.Getenv(SechubIgnoreDefaultExcludesEnvVar) == "true" // make it possible to switch off default excludes
 	config.keepTempFiles =

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
@@ -132,6 +132,9 @@ const SechubApitokenEnvVar = "SECHUB_APITOKEN"
 // SechubDebugEnvVar - environment variable to enable debug output
 const SechubDebugEnvVar = "SECHUB_DEBUG"
 
+// SechubDebugHTTPEnvVar - environment variable to enable additional HTTP logging
+const SechubDebugHTTPEnvVar = "SECHUB_DEBUG_HTTP"
+
 // SechubIgnoreDefaultExcludesEnvVar - environment variable to make it possible to switch off default excludes (DefaultZipExcludeDirPatterns)
 const SechubIgnoreDefaultExcludesEnvVar = "SECHUB_IGNORE_DEFAULT_EXCLUDES"
 

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/controller-uploadsourcezip.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/controller-uploadsourcezip.go
@@ -27,8 +27,11 @@ func uploadSourceZipFile(context *Context) {
 
 	request, err := newFileUploadRequestViaPipe(buildUploadSourceCodeAPICall(context), extraParams, "file", context.sourceZipFileName)
 	sechubUtil.HandleError(err, ExitCodeIOError)
-	sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("Sending %v:%v", request.Method, request.URL))
-	sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("Content length of upload request: %d bytes", request.ContentLength))
+
+	if context.config.debug || context.config.debugHTTP {
+		sechubUtil.LogDebug(true, fmt.Sprintf("HTTP %v %v", request.Method, request.URL))
+		sechubUtil.LogDebug(true, fmt.Sprintf("Content length of HTTP upload request: %d bytes", request.ContentLength))
+	}
 
 	request.SetBasicAuth(context.config.user, context.config.apiToken)
 

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/report.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/report.go
@@ -105,7 +105,7 @@ func newSecHubReportFromFile(context *Context) SecHubReport {
 	jsonFile, err := os.Open(context.config.file)
 	if sechubUtil.HandleIOError(err) {
 		showHelpHint()
-		os.Exit(ExitCodeIOError)
+		os.Exit(ExitCodeIOError) // exiting from go implicitely closes all open files
 	}
 	defer jsonFile.Close()
 

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/report.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/report.go
@@ -95,7 +95,6 @@ func getSecHubJobReport(context *Context) []byte {
 	data, err := ioutil.ReadAll(response.Body)
 	sechubUtil.HandleHTTPError(err, ExitCodeHTTPError)
 
-	sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("SecHub job report: %s", string(data)))
 	return data
 }
 
@@ -104,12 +103,11 @@ func newSecHubReportFromFile(context *Context) SecHubReport {
 
 	/* open file and check exists */
 	jsonFile, err := os.Open(context.config.file)
-	defer jsonFile.Close()
-
 	if sechubUtil.HandleIOError(err) {
 		showHelpHint()
 		os.Exit(ExitCodeIOError)
 	}
+	defer jsonFile.Close()
 
 	var filecontent []byte
 	filecontent, err = ioutil.ReadAll(jsonFile)

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/resthelper.go
@@ -28,7 +28,11 @@ func sendWithDefaultHeader(method string, url string, context *Context) *http.Re
 
 func sendWithHeader(method string, url string, context *Context, header map[string]string) *http.Response {
 	/* we use inputForContentProcessing - means origin content, unfilled, prevents password leak in logs */
-	sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("Sending %s:%s\n Headers: %s\n Origin-Content: %q", method, url, header, context.inputForContentProcessing))
+	if context.config.debugHTTP {
+		sechubUtil.LogDebug(true, fmt.Sprintf("HTTP %s %s\n Headers: %s\n Origin-Content: %q", method, url, header, context.inputForContentProcessing))
+	} else {
+		sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("HTTP %s %s\n", method, url))
+	}
 
 	/* prepare */
 	request, err1 := http.NewRequest(method, url, bytes.NewBuffer(context.contentToSend)) // we use "contentToSend" and not "inputForContentProcessing" !
@@ -68,7 +72,11 @@ func handleHTTPRequestAndResponse(context *Context, request *http.Request) *http
 		}
 	}
 
-	sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("HTTP response: %+v", response))
+	if context.config.debugHTTP {
+		sechubUtil.LogDebug(true, fmt.Sprintf("HTTP response:\n%+v", response))
+	} else {
+		sechubUtil.LogDebug(context.config.debug, fmt.Sprintf("HTTP response code: %d", response.StatusCode))
+	}
 	sechubUtil.HandleHTTPResponse(response, ExitCodeHTTPError) // Will exit if we still got a 4xx or 5xx StatusCode
 
 	return response

--- a/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
@@ -320,7 +320,9 @@ Additionally to above cmdline options, you can set some values also via environm
 Settings for debugging/client development:
 
 - `SECHUB_DEBUG` +
-  When set to `true` then log as much as possible
+  When set to `true` then log as much as possible (but not HTTP request contents)
+- `SECHUB_DEBUG_HTTP` +
+  When set to `true` then log HTTP request contents.
 - `SECHUB_IGNORE_DEFAULT_EXCLUDES` +
   When set to `true` then default exclude folders `+{"**/test/**", "**/.git/**"}+` will be included for code scan. In this case, you should declare your own exclude list in the config json.
 - `SECHUB_KEEP_TEMPFILES` +

--- a/sechub-doc/src/docs/asciidoc/documents/techdoc/02_security_in_development.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/techdoc/02_security_in_development.adoc
@@ -10,10 +10,11 @@ used in production. So instead of exposing such options by help we
 use those by explicit ENV entries
 [options="header",cols="1,1,1"]
 |===
-|ENV-NAME       |Value    |Description
+|ENV-NAME          |Value    |Description
 //-----------------------------------------
-|SECHUB_DEBUG   |"true"   |Shows debug outputs
-|SECHUB_TRUSTALL|"true"   |Trust all certificates (only for development). Normally SecHub client does show a warning when `trustall` option is enabled
+|SECHUB_DEBUG      |"true"   |Activates debug logging
+|SECHUB_DEBUG_HTTP |"true"   |Shows HTTP request+response contents including headers
+|SECHUB_TRUSTALL   |"true"   |Trust all certificates (only for development). The SecHub client shows a warning when `trustall` option is enabled
 |===
 
 === Server


### PR DESCRIPTION
- when debugging is enabled, log only HTTP calls but no contents
- never print SecHub report raw data to STDOUT
- docs are also updated

closes #1168 