### PR TITLE
Feature 1174 client intelligent polling

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
@@ -104,7 +104,7 @@ func prepareOptionsFromCommandline(config *Config) {
 	flag.BoolVar(&flagVersion,
 		versionOption, false, "Shows version info and terminates")
 	flag.IntVar(&config.waitSeconds,
-		waitOption, config.waitSeconds, "Wait time in seconds - For status checks of action='"+scanAction+"' and for retries of HTTP calls. Can also be defined in environment variable "+SechubWaittimeDefaultEnvVar)
+		waitOption, config.waitSeconds, "Maximal wait time in seconds - For status checks of action='"+scanAction+"' and for retries of HTTP calls. Can also be defined in environment variable "+SechubWaittimeDefaultEnvVar)
 }
 
 func parseConfigFromEnvironment(config *Config) {

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
@@ -104,7 +104,7 @@ func prepareOptionsFromCommandline(config *Config) {
 	flag.BoolVar(&flagVersion,
 		versionOption, false, "Shows version info and terminates")
 	flag.IntVar(&config.waitSeconds,
-		waitOption, config.waitSeconds, "Maximal wait time in seconds - For status checks of action='"+scanAction+"' and for retries of HTTP calls. Can also be defined in environment variable "+SechubWaittimeDefaultEnvVar)
+		waitOption, config.waitSeconds, "Maximum wait time in seconds - For status checks of action='"+scanAction+"' and for retries of HTTP calls. Can also be defined in environment variable "+SechubWaittimeDefaultEnvVar)
 }
 
 func parseConfigFromEnvironment(config *Config) {
@@ -373,14 +373,14 @@ func validateOutputLocation(config *Config) bool {
 	return true
 }
 
-func validateWaitTimeOrWarning(waittime int) int {
+func validateWaitTimeOrWarning(waitTime int) int {
 	// Verify wait time and ensure MinimalWaitTimeSeconds
-	if waittime < MinimalWaitTimeSeconds {
+	if waitTime < MinimalWaitTimeSeconds {
 		sechubUtil.LogWarning(
-			fmt.Sprintf("Desired wait intervall (%d s) is too small. Setting to %d seconds.", waittime, MinimalWaitTimeSeconds))
-		waittime = MinimalWaitTimeSeconds
+			fmt.Sprintf("Desired wait intervall (%d s) is too small. Setting to %d seconds.", waitTime, MinimalWaitTimeSeconds))
+		waitTime = MinimalWaitTimeSeconds
 	}
-	return waittime
+	return waitTime
 }
 
 func validateTimeoutOrWarning(timeout int) int {

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
@@ -356,26 +356,26 @@ func Test_validateOutputLocation_empty(t *testing.T) {
 
 func Test_validateWaitTimeOrWarning(t *testing.T) {
 	// PREPARE
-	bigvalue := 10000000
+	bigValue := 10000000
 
 	// EXECUTE
 	result1 := validateWaitTimeOrWarning(0)
-	result2 := validateWaitTimeOrWarning(bigvalue)
+	result2 := validateWaitTimeOrWarning(bigValue)
 
 	// TEST
 	sechubTestUtil.AssertEquals(MinimalWaitTimeSeconds, result1, t)
-	sechubTestUtil.AssertEquals(bigvalue, result2, t)
+	sechubTestUtil.AssertEquals(bigValue, result2, t)
 }
 
 func Test_validateTimeoutOrWarning(t *testing.T) {
 	// PREPARE
-	bigvalue := 10000000
+	bigValue := 10000000
 
 	// EXECUTE
 	result1 := validateTimeoutOrWarning(0)
-	result2 := validateTimeoutOrWarning(bigvalue)
+	result2 := validateTimeoutOrWarning(bigValue)
 
 	// TEST
 	sechubTestUtil.AssertEquals(MinimalTimeoutInSeconds, result1, t)
-	sechubTestUtil.AssertEquals(bigvalue, result2, t)
+	sechubTestUtil.AssertEquals(bigValue, result2, t)
 }

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
@@ -353,3 +353,29 @@ func Test_validateOutputLocation_empty(t *testing.T) {
 	sechubTestUtil.AssertEquals(".", config.outputFolder, t)
 	sechubTestUtil.AssertEquals("", config.outputFileName, t)
 }
+
+func Test_validateWaitTimeOrWarning(t *testing.T) {
+	// PREPARE
+	bigvalue := 10000000
+
+	// EXECUTE
+	result1 := validateWaitTimeOrWarning(0)
+	result2 := validateWaitTimeOrWarning(bigvalue)
+
+	// TEST
+	sechubTestUtil.AssertEquals(MinimalWaitTimeSeconds, result1, t)
+	sechubTestUtil.AssertEquals(bigvalue, result2, t)
+}
+
+func Test_validateTimeoutOrWarning(t *testing.T) {
+	// PREPARE
+	bigvalue := 10000000
+
+	// EXECUTE
+	result1 := validateTimeoutOrWarning(0)
+	result2 := validateTimeoutOrWarning(bigvalue)
+
+	// TEST
+	sechubTestUtil.AssertEquals(MinimalTimeoutInSeconds, result1, t)
+	sechubTestUtil.AssertEquals(bigvalue, result2, t)
+}

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
@@ -24,7 +24,7 @@ const DefaultTempDir = "."
 const DefaultWaitTime = 60
 
 // MinimalWaitTimeSeconds - We don't allow intervals shorter than this to protect the SecHub server
-const MinimalWaitTimeSeconds = 4
+const MinimalWaitTimeSeconds = 3
 
 // InitialWaitIntervallSeconds WaitIntervallIncreaseFactor - defines client's polling behaviour:
 // 2s - 3s - 4.5s - 7s - 10s - 15s - 23s - 34s - 51s - 60s - 60s - 60s ...

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
@@ -2,6 +2,8 @@
 
 package cli
 
+import "time"
+
 // CurrentAPIVersion - SecHub current api version
 const CurrentAPIVersion = "1.0"
 
@@ -17,12 +19,24 @@ const DefaultTempDir = "."
 
 // DefaultWaitTime - Wait time in seconds.
 // Will be used
-// - for automatic status checks etc. when action=scan
+// - for maximum pause between automatic status checks when action=scan
 // - for pause between retries for failed HTTP calls
 const DefaultWaitTime = 60
 
+// MinimalWaitTimeSeconds - We don't allow intervals shorter than this to protect the SecHub server
+const MinimalWaitTimeSeconds = 4
+
+// InitialWaitIntervallSeconds WaitIntervallIncreaseFactor - defines client's polling behaviour:
+// 2s - 3s - 4.5s - 7s - 10s - 15s - 23s - 34s - 51s - 60s - 60s - 60s ...
+const InitialWaitIntervallSeconds = 2
+const InitialWaitIntervallNanoseconds = int64(InitialWaitIntervallSeconds * time.Second)
+const WaitIntervallIncreaseFactor = 1.5
+
 // DefaultTimeoutInSeconds - Timeout for network communication in seconds
 const DefaultTimeoutInSeconds = 120
+
+// MinimalTimeoutInSeconds - Minimal allowed timeout setting
+const MinimalTimeoutInSeconds = 10
 
 // DefaultZipExcludeDirPatterns - Define directory patterns to exclude from zip file:
 // - code in directories named "test" is not considered to end up in the binary

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
@@ -41,7 +41,7 @@ func approveSecHubJob(context *Context) {
 }
 
 func waitForSecHubJobDone(context *Context) (status jobStatusResult) {
-	cursor := 0
+	var cursor uint8 = 0
 	waitNanoseconds := InitialWaitIntervallNanoseconds
 
 	sechubUtil.Log(fmt.Sprintf("Waiting for job %s to be done", context.config.secHubJobUUID), context.config.quiet)
@@ -67,7 +67,7 @@ func waitForSecHubJobDone(context *Context) (status jobStatusResult) {
 }
 
 // Print progress dots ... 50 dots, then next line...
-func printProgressDot(cursor int) int {
+func printProgressDot(cursor uint8) uint8 {
 	if cursor == 0 {
 		// initial identation
 		fmt.Print(strings.Repeat(" ", 29))
@@ -75,7 +75,8 @@ func printProgressDot(cursor int) int {
 
 	fmt.Print(".")
 
-	if cursor++; cursor == 50 {
+	cursor++
+	if cursor == 50 {
 		fmt.Print("\n")
 		cursor = 0
 	}

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
@@ -41,8 +41,8 @@ func approveSecHubJob(context *Context) {
 }
 
 func waitForSecHubJobDone(context *Context) (status jobStatusResult) {
-	newLine := true
 	cursor := 0
+	waitNanoseconds := InitialWaitIntervallNanoseconds
 
 	sechubUtil.Log(fmt.Sprintf("Waiting for job %s to be done", context.config.secHubJobUUID), context.config.quiet)
 
@@ -53,22 +53,42 @@ func waitForSecHubJobDone(context *Context) (status jobStatusResult) {
 			break
 		}
 
-		// PROGRESS bar ... 50 chars with dot, then next line...
-		if newLine {
-			sechubUtil.PrintIfNotSilent(strings.Repeat(" ", 29), context.config.quiet)
-			newLine = false
+		if !context.config.quiet {
+			// Progress dots
+			cursor = printProgressDot(cursor)
 		}
-		sechubUtil.PrintIfNotSilent(".", context.config.quiet)
-		if cursor++; cursor == 50 {
-			sechubUtil.PrintIfNotSilent("\n", context.config.quiet)
-			cursor = 0
-			newLine = true
-		}
-		time.Sleep(time.Duration(context.config.waitNanoseconds))
+
+		time.Sleep(time.Duration(waitNanoseconds))
+		waitNanoseconds = computeNextWaitInterval(waitNanoseconds, context.config.waitNanoseconds)
 	}
 	sechubUtil.PrintIfNotSilent("\n", context.config.quiet)
 
 	return status
+}
+
+// Print progress dots ... 50 dots, then next line...
+func printProgressDot(cursor int) int {
+	if cursor == 0 {
+		// initial identation
+		fmt.Print(strings.Repeat(" ", 29))
+	}
+
+	fmt.Print(".")
+
+	if cursor++; cursor == 50 {
+		fmt.Print("\n")
+		cursor = 0
+	}
+
+	return cursor
+}
+
+func computeNextWaitInterval(current int64, max int64) int64 {
+	next := int64(float64(current) * WaitIntervallIncreaseFactor)
+	if next > max {
+		return max
+	}
+	return next
 }
 
 func getSecHubJobStatus(context *Context) (jsonData string) {

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/job_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/job_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"fmt"
+	"time"
+)
+
+func Example_computeNextWaitInterval() {
+	/* prepare */
+	max := int64(60 * time.Second)
+
+	/* execute */
+	result1 := computeNextWaitInterval(int64(100*time.Second), max)
+	result2 := computeNextWaitInterval(int64(10*time.Second), max)
+
+	/* test */
+	fmt.Println(result1)
+	fmt.Println(result2)
+	// Output:
+	// 60000000000
+	// 15000000000
+}

--- a/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
@@ -86,9 +86,9 @@ Does scan synchronous which means
  - approve job as being ready to start
  - wait for job done,
  - fetch automatically result report to output folder (html or json)
- - returns non-zero on `red` (so usually your build will break on critical or high findings)
+ - returns non-zero on `red` so your build will break on critical or high findings (depends on your build tool)
 
-IMPORTANT: For security reasons always pass your api token via the environment variable `SECHUB_APITOKEN`.
+IMPORTANT: For security reasons always pass your API-token via the environment variable `SECHUB_APITOKEN`.
 
 TIP: The is the most preferred scan action for builds - you only have to make one
      single client call and your are done.
@@ -296,7 +296,7 @@ Here is an overview of mandatory parameter for each `action`:
 - `-version` +
   Shows version info and terminates
 - `-wait <seconds>` + 
-       Maximal wait time in seconds (default 60). 
+       Maximum wait time in seconds (default 60). 
        Will be used for periodic status checks when action=`scan` and for retries of HTTP calls.
 
 ==== Environment variables
@@ -330,7 +330,7 @@ Settings for debugging/client development:
 - `SECHUB_KEEP_TEMPFILES` +
   When set to `true` then `sourcecode-<projectID>.zip` files for code scan will not be removed, so you can check, what was uploaded to the `{sechub}` server.
 - `SECHUB_WAITTIME_DEFAULT` +
-  Maximal wait time in seconds (default 60). Will be used for automatic status checks etc. when action=`scan`.
+  Maximum wait time in seconds (default 60). Will be used for automatic status checks etc. when action=`scan`.
 
 
 ==== Proxy support

--- a/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
@@ -231,7 +231,7 @@ In below table, there is an overview of what can be defined where.
 | job uuid | -jobUUID ||
 | network timeout | -timeout||
 | output folder or file | -output ||
-| poll interval | -wait | SECHUB_WAITTIME_DEFAULT |
+| max. poll interval | -wait | SECHUB_WAITTIME_DEFAULT |
 | project id | -project | SECHUB_PROJECT |project
 | quiet mode | -quiet | SECHUB_QUIET |
 | report format | -reportformat||
@@ -296,7 +296,7 @@ Here is an overview of mandatory parameter for each `action`:
 - `-version` +
   Shows version info and terminates
 - `-wait <seconds>` + 
-       Wait time in seconds (default 60). 
+       Maximal wait time in seconds (default 60). 
        Will be used for periodic status checks when action=`scan` and for retries of HTTP calls.
 
 ==== Environment variables
@@ -330,8 +330,7 @@ Settings for debugging/client development:
 - `SECHUB_KEEP_TEMPFILES` +
   When set to `true` then `sourcecode-<projectID>.zip` files for code scan will not be removed, so you can check, what was uploaded to the `{sechub}` server.
 - `SECHUB_WAITTIME_DEFAULT` +
-  Wait time in seconds (default 60). Will be used for automatic status checks etc. when action=`scan`.
-  Try to avoid setting it shorter than 60 seconds, because the load on the `{sechub}` server will be increased.
+  Maximal wait time in seconds (default 60). Will be used for automatic status checks etc. when action=`scan`.
 
 
 ==== Proxy support

--- a/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
@@ -86,9 +86,9 @@ Does scan synchronous which means
  - approve job as being ready to start
  - wait for job done,
  - fetch automatically result report to output folder (html or json)
- - break your build when not `green`
+ - returns non-zero on `red` (so usually your build will break on critical or high findings)
 
-TIP: For security reasons always pass your api token via the environment variable `SECHUB_APITOKEN`.
+IMPORTANT: For security reasons always pass your api token via the environment variable `SECHUB_APITOKEN`.
 
 TIP: The is the most preferred scan action for builds - you only have to make one
      single client call and your are done.


### PR DESCRIPTION
- client polls in increasing intervals, so results from quick backends (e.g. PDS-GoSec) are available earlier
- maximal poll interval is still the defined wait time (default: 60s)
- unit tests added
- docs + client help output updated
- code readability improved (moved progress dot printing into an extra func)

closes #1174 