### PR TITLE
Feature 1266 client enable quicker tests

### DIFF
--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
@@ -393,7 +393,7 @@ func validateWaitTimeOrWarning(waitTime int) int {
 	// Verify wait time and ensure MinimalWaitTimeSeconds
 	if waitTime < MinimalWaitTimeSeconds {
 		sechubUtil.LogWarning(
-			fmt.Sprintf("Desired wait interval (%d s) is too small. Setting to %d seconds.", waitTime, MinimalWaitTimeSeconds))
+			fmt.Sprintf("Desired wait interval (%d s) is too short. Setting it to %d seconds.", waitTime, MinimalWaitTimeSeconds))
 		waitTime = MinimalWaitTimeSeconds
 	}
 	return waitTime
@@ -404,7 +404,7 @@ func validateInitialWaitIntervalOrWarning(intervalNanoseconds int64) int64 {
 	// Verify wait time and ensure minimalInitialWaitIntervalNanoseconds
 	if intervalNanoseconds < minimalInitialWaitIntervalNanoseconds {
 		sechubUtil.LogWarning(
-			fmt.Sprintf("Desired initial wait interval (%v s) is too small. Setting to %v s.",
+			fmt.Sprintf("Desired initial wait interval (%v s) is too short. Setting it to %v s.",
 				float64(intervalNanoseconds)/float64(time.Second),
 				float64(minimalInitialWaitIntervalNanoseconds)/float64(time.Second)))
 		intervalNanoseconds = minimalInitialWaitIntervalNanoseconds

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config.go
@@ -17,41 +17,43 @@ import (
 
 // Config for internal CLI calls
 type Config struct {
-	action                string
-	apiToken              string
-	configFilePath        string
-	configFileRead        bool
-	debug                 bool
-	debugHTTP             bool
-	file                  string
-	ignoreDefaultExcludes bool
-	keepTempFiles         bool
-	outputFileName        string
-	outputFolder          string
-	outputLocation        string
-	projectID             string
-	quiet                 bool
-	reportFormat          string
-	secHubJobUUID         string
-	server                string
-	stopOnYellow          bool
-	tempDir               string
-	timeOutNanoseconds    int64
-	timeOutSeconds        int
-	trustAll              bool
-	user                  string
-	waitNanoseconds       int64
-	waitSeconds           int
-	whitelistAll          bool
+	action                         string
+	apiToken                       string
+	configFilePath                 string
+	configFileRead                 bool
+	debug                          bool
+	debugHTTP                      bool
+	file                           string
+	ignoreDefaultExcludes          bool
+	initialWaitIntervalNanoseconds int64
+	keepTempFiles                  bool
+	outputFileName                 string
+	outputFolder                   string
+	outputLocation                 string
+	projectID                      string
+	quiet                          bool
+	reportFormat                   string
+	secHubJobUUID                  string
+	server                         string
+	stopOnYellow                   bool
+	tempDir                        string
+	timeOutNanoseconds             int64
+	timeOutSeconds                 int
+	trustAll                       bool
+	user                           string
+	waitNanoseconds                int64
+	waitSeconds                    int
+	whitelistAll                   bool
 }
 
 // Initialize Config with default values
 var configFromInit Config = Config{
-	configFilePath: DefaultSecHubConfigFile,
-	reportFormat:   DefaultReportFormat,
-	tempDir:        DefaultTempDir,
-	timeOutSeconds: DefaultTimeoutInSeconds,
-	waitSeconds:    DefaultWaitTime,
+	configFilePath:                 DefaultSecHubConfigFile,
+	initialWaitIntervalNanoseconds: int64(DefaultinitialWaitIntervalSeconds * time.Second),
+	reportFormat:                   DefaultReportFormat,
+	tempDir:                        DefaultTempDir,
+	timeOutSeconds:                 DefaultTimeoutInSeconds,
+	waitSeconds:                    DefaultWaitTime,
 }
 
 var flagHelp bool
@@ -122,6 +124,8 @@ func parseConfigFromEnvironment(config *Config) {
 		os.Getenv(SechubQuietEnvVar) == "true"
 	config.trustAll =
 		os.Getenv(SechubTrustAllEnvVar) == "true"
+	initialWaitIntervalFromEnv :=
+		os.Getenv(SechubIninitialWaitIntervalSecondsEnvVar)
 	projectFromEnv :=
 		os.Getenv(SechubProjectEnvVar)
 	serverFromEnv :=
@@ -137,6 +141,14 @@ func parseConfigFromEnvironment(config *Config) {
 
 	if apiTokenFromEnv != "" {
 		config.apiToken = apiTokenFromEnv
+	}
+	if initialWaitIntervalFromEnv != "" {
+		initialWaitInterval, err := strconv.ParseFloat(initialWaitIntervalFromEnv, 64)
+		if err == nil {
+			config.initialWaitIntervalNanoseconds = int64(initialWaitInterval * float64(time.Second))
+		} else {
+			sechubUtil.LogWarning(fmt.Sprintf("Could not parse '%v' as number (read from $%s)", initialWaitIntervalFromEnv, SechubIninitialWaitIntervalSecondsEnvVar))
+		}
 	}
 	if projectFromEnv != "" {
 		config.projectID = projectFromEnv
@@ -261,6 +273,8 @@ func assertValidConfig(config *Config) {
 	// Remove trailing slash from url if present
 	config.server = strings.TrimSuffix(config.server, "/")
 
+	config.initialWaitIntervalNanoseconds = validateInitialWaitIntervalOrWarning(config.initialWaitIntervalNanoseconds)
+
 	config.waitSeconds = validateWaitTimeOrWarning(config.waitSeconds)
 	config.waitNanoseconds = int64(config.waitSeconds) * int64(time.Second)
 
@@ -379,10 +393,23 @@ func validateWaitTimeOrWarning(waitTime int) int {
 	// Verify wait time and ensure MinimalWaitTimeSeconds
 	if waitTime < MinimalWaitTimeSeconds {
 		sechubUtil.LogWarning(
-			fmt.Sprintf("Desired wait intervall (%d s) is too small. Setting to %d seconds.", waitTime, MinimalWaitTimeSeconds))
+			fmt.Sprintf("Desired wait interval (%d s) is too small. Setting to %d seconds.", waitTime, MinimalWaitTimeSeconds))
 		waitTime = MinimalWaitTimeSeconds
 	}
 	return waitTime
+}
+
+func validateInitialWaitIntervalOrWarning(intervalNanoseconds int64) int64 {
+	minimalInitialWaitIntervalNanoseconds := int64(MinimalInitialWaitIntervalSeconds * float64(time.Second))
+	// Verify wait time and ensure minimalInitialWaitIntervalNanoseconds
+	if intervalNanoseconds < minimalInitialWaitIntervalNanoseconds {
+		sechubUtil.LogWarning(
+			fmt.Sprintf("Desired initial wait interval (%v s) is too small. Setting to %v s.",
+				float64(intervalNanoseconds)/float64(time.Second),
+				float64(minimalInitialWaitIntervalNanoseconds)/float64(time.Second)))
+		intervalNanoseconds = minimalInitialWaitIntervalNanoseconds
+	}
+	return intervalNanoseconds
 }
 
 func validateTimeoutOrWarning(timeout int) int {

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	sechubTestUtil "mercedes-benz.com/sechub/testutil"
 )
@@ -381,6 +382,20 @@ func Test_validateTimeoutOrWarning(t *testing.T) {
 	sechubTestUtil.AssertEquals(bigValue, result2, t)
 }
 
+func Test_validateInitialWaitIntervalOrWarning(t *testing.T) {
+	// PREPARE
+	var okay int64 = 60 * int64(time.Second) // 60s
+	var tooSmall int64 = 10000000            // 0.01s
+
+	// EXECUTE
+	result1 := validateInitialWaitIntervalOrWarning(okay)
+	result2 := validateInitialWaitIntervalOrWarning(tooSmall)
+
+	// TEST
+	sechubTestUtil.AssertEquals(okay, result1, t)
+	sechubTestUtil.AssertEquals(int64(MinimalInitialWaitIntervalSeconds*float64(time.Second)), result2, t)
+}
+
 func Example_will_reportfile_be_found_in_current_dir() {
 	// PREPARE
 	var config Config
@@ -392,6 +407,7 @@ func Example_will_reportfile_be_found_in_current_dir() {
 	config.server = "https://test.example.org"
 	config.reportFormat = "json"
 	config.timeOutSeconds = 10
+	config.initialWaitIntervalNanoseconds = int64(2 * float64(time.Second))
 	config.waitSeconds = 60
 
 	// Create report file: sechub_report_testproject_45cd4f59-4be7-4a86-9bc7-47528ced16c2.json

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/config_test.go
@@ -384,8 +384,8 @@ func Test_validateTimeoutOrWarning(t *testing.T) {
 
 func Test_validateInitialWaitIntervalOrWarning(t *testing.T) {
 	// PREPARE
-	var okay int64 = 60 * int64(time.Second) // 60s
-	var tooSmall int64 = 10000000            // 0.01s
+	var okay int64 = 60 * int64(time.Second)                // 60s
+	var tooSmall int64 = int64(0.01 * float64(time.Second)) // 0.01s
 
 	// EXECUTE
 	result1 := validateInitialWaitIntervalOrWarning(okay)

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/constants.go
@@ -24,13 +24,16 @@ const DefaultTempDir = "."
 const DefaultWaitTime = 60
 
 // MinimalWaitTimeSeconds - We don't allow intervals shorter than this to protect the SecHub server
-const MinimalWaitTimeSeconds = 3
+const MinimalWaitTimeSeconds = 1
 
-// InitialWaitIntervallSeconds WaitIntervallIncreaseFactor - defines client's polling behaviour:
+// initialWaitIntervalSeconds WaitIntervalIncreaseFactor - defines client's polling behaviour:
 // 2s - 3s - 4.5s - 7s - 10s - 15s - 23s - 34s - 51s - 60s - 60s - 60s ...
-const InitialWaitIntervallSeconds = 2
-const InitialWaitIntervallNanoseconds = int64(InitialWaitIntervallSeconds * time.Second)
-const WaitIntervallIncreaseFactor = 1.5
+const DefaultinitialWaitIntervalSeconds = 2
+const InitialWaitIntervalNanoseconds = int64(DefaultinitialWaitIntervalSeconds * time.Second)
+const WaitIntervalIncreaseFactor = 1.5
+
+// MinimalInitialWaitIntervalSeconds - small value to enable quick integration tests. In real life: please stick with DefaultinitialWaitIntervalSeconds.
+const MinimalInitialWaitIntervalSeconds = 0.1
 
 // DefaultTimeoutInSeconds - Timeout for network communication in seconds
 const DefaultTimeoutInSeconds = 120
@@ -151,6 +154,9 @@ const SechubDebugHTTPEnvVar = "SECHUB_DEBUG_HTTP"
 
 // SechubIgnoreDefaultExcludesEnvVar - environment variable to make it possible to switch off default excludes (DefaultZipExcludeDirPatterns)
 const SechubIgnoreDefaultExcludesEnvVar = "SECHUB_IGNORE_DEFAULT_EXCLUDES"
+
+// SechubIgnoreDefaultExcludesEnvVar - environment variable to make it possible to switch off default excludes (DefaultZipExcludeDirPatterns)
+const SechubIninitialWaitIntervalSecondsEnvVar = "SECHUB_INITIAL_WAIT_INTERVAL"
 
 // SechubKeepTempfilesEnvVar - environment variable to keep temporary files
 const SechubKeepTempfilesEnvVar = "SECHUB_KEEP_TEMPFILES"

--- a/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
+++ b/sechub-cli/src/mercedes-benz.com/sechub/cli/job.go
@@ -42,7 +42,7 @@ func approveSecHubJob(context *Context) {
 
 func waitForSecHubJobDone(context *Context) (status jobStatusResult) {
 	var cursor uint8 = 0
-	waitNanoseconds := InitialWaitIntervallNanoseconds
+	waitNanoseconds := context.config.initialWaitIntervalNanoseconds
 
 	sechubUtil.Log(fmt.Sprintf("Waiting for job %s to be done", context.config.secHubJobUUID), context.config.quiet)
 
@@ -85,7 +85,7 @@ func printProgressDot(cursor uint8) uint8 {
 }
 
 func computeNextWaitInterval(current int64, max int64) int64 {
-	next := int64(float64(current) * WaitIntervallIncreaseFactor)
+	next := int64(float64(current) * WaitIntervalIncreaseFactor)
 	if next > max {
 		return max
 	}

--- a/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/code2doc/client/02_sechub_client.adoc
@@ -327,6 +327,8 @@ Settings for debugging/client development:
   When set to `true` then log HTTP request contents.
 - `SECHUB_IGNORE_DEFAULT_EXCLUDES` +
   When set to `true` then default exclude folders `+{"**/test/**", "**/.git/**"}+` will be included for code scan. In this case, you should declare your own exclude list in the config json.
+- `SECHUB_INITIAL_WAIT_INTERVAL` +
+  Initial wait time (floating point number) until SecHub client polls the first time if the report is ready (`sechub scan`). Meant for local integration tests.
 - `SECHUB_KEEP_TEMPFILES` +
   When set to `true` then `sourcecode-<projectID>.zip` files for code scan will not be removed, so you can check, what was uploaded to the `{sechub}` server.
 - `SECHUB_WAITTIME_DEFAULT` +

--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/SecHubClientExecutor.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/internal/SecHubClientExecutor.java
@@ -206,6 +206,7 @@ public class SecHubClientExecutor {
 
         Map<String, String> environment = pb.environment();
         environment.put("SECHUB_TRUSTALL", "" + trustAll);
+        environment.put("SECHUB_INITIAL_WAIT_INTERVAL", "0.1");
 
         if (IntegrationTestSetup.SECHUB_CLIENT_DEBUGGING_ENABLED) {
             // we enable only when explicit wanted - so logs are smaller and easier to read


### PR DESCRIPTION
- made initial wait interval configurable (min. 0.1s)
- integrationtests use above setting (speedup: ~23s)
- typo fix (intervall -> interval)
- docs and unit tests updated

closes #1266 