### PR TITLE
Feature 1276 PDS Solutions: make report cleanup configurable

### DIFF
--- a/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/Chart.yaml
+++ b/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/templates/deployment.yaml
+++ b/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
                     - name: PDS_CONFIG_EXECUTE_QUEUE_MAX
                       value: "{{ .Values.pds.config.execute.queueMax }}"
                     - name: PDS_CONFIG_EXECUTE_WORKER_THREAD_COUNT
-                      value: "{{ .Values.pds.config.execute.workerThreatCount }}"
+                      value: "{{ .Values.pds.config.execute.workerThreadCount }}"
                     - name: ZAP_PROXY_HOST
                       value: "{{ .Values.zap.proxy.host }}"
                     - name: ZAP_PROXY_PORT
@@ -45,6 +45,10 @@ spec:
                     {{- if .Values.zap.proxy.forPdsTargetType }}
                     - name: ZAP_PROXY_FOR_PDS_TARGET_TYPE
                       value: "{{ .Values.zap.proxy.forPdsTargetType }}"
+                    {{- end }}
+                    {{- if .Values.pds.debug.keepReportsInWorkspace }}
+                    - name: SECHUB_PDS_WORKSPACE_AUTOCLEAN_DISABLED
+                      value: "true"
                     {{- end }}
                     {{- if .Values.pds.javaDebug.enabled }}
                     - name: JAVA_ENABLE_DEBUG

--- a/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/values.yaml
+++ b/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/values.yaml
@@ -10,13 +10,15 @@ image:
 
 pds:
     startMode: localserver
-    javaDebug:
-        enabled: false
-    keepContainerAliveAfterPDSCrashed: false
     config:
         execute:
             queueMax: 10
-            workerThreatCount: 1
+            workerThreadCount: 1
+    debug:
+        keepReportsInWorkspace: false
+    javaDebug:
+        enabled: false
+    keepContainerAliveAfterPDSCrashed: false
 
 zap:
     apiKey: "<random-api-key>"


### PR DESCRIPTION
Updated Helm charts + values.yaml so env variable SECHUB_PDS_WORKSPACE_AUTOCLEAN_DISABLED is set if configured:
- PDS-OWASPZAP
- PDS-GoSec
- PDS-Multi
- PDS-ScanCode

Others:
- typo fixed (threat vs. thread)

closes #1276 