### PR TITLE
Scancode support binary uploads

### DIFF
--- a/sechub-developertools/scripts/pds-api.sh
+++ b/sechub-developertools/scripts/pds-api.sh
@@ -27,7 +27,7 @@ ACTION [PARAMETERS] - EXPLANATION
 check_alive - Check if the server is running.
 create_job <product-id> <sechub-job-uuid> - Create a new job using <product-id> and a <sechub-job-uuid>.
 create_job_from_json <json-file> - Create a new job using a <json-file> JSON file.
-upload_zip <job-uuid> <zip-file> - Upload a <zip-file> ZIP file for an existing job <job-uuid>.
+upload <job-uuid> <file> - Upload a <file> file for an existing job <job-uuid>.
 mark_job_ready_to_start <job-uuid> - Mark a job with <job-uuid> as ready to start.
 job_status <job-uuid> - Get the status of a job using the <job-uuid>.
 job_result <job-uuid> - Get the job result using the <job-uuid>
@@ -105,33 +105,43 @@ function create_job_from_json {
 
 
 function generate_pds_job_data {
+  local sechub_job_uuid="$1"
+  local product_id="$2"
+
   cat <<EOF
 {
   "apiVersion":"$PDS_API_VERSION",
-  "sechubJobUUID":"$1",
-  "productId":"$2"
+  "sechubJobUUID":"$sechub_job_uuid",
+  "productId":"$product_id"
 }
 EOF
 }
 
-function upload_zip {
+function upload {
   local jobUUID=$1
-  local zip_file=$2
+  local file_to_upload=$2
+  local upload_file_name="sourcecode.zip"
 
-  if [[ ! -f "$zip_file" ]] ; then
-    echo "File \"$zip_file\" does not exist."
+  if [[ ! -f "$file_to_upload" ]] ; then
+    echo "File \"$file_to_upload\" does not exist."
     exit 1
   fi
 
-  local checkSum=$(sha256sum $zip_file | cut --delimiter=' ' --fields=1)
+  local file_to_upload_lowercased=$( echo "$file_to_upload" | tr '[:upper:]' '[:lower:]' )
+  if [[ "$file_to_upload_lowercased" == *.tar ]]
+  then
+    upload_file_name="binaries.tar"
+  fi
+
+  local checkSum=$(sha256sum $file_to_upload | cut --delimiter=' ' --fields=1)
 
   curl $CURL_AUTH $CURL_PARAMS -i -X POST --header "Content-Type: multipart/form-data" \
-    --form "file=@$zip_file" \
+    --form "file=@$file_to_upload" \
     --form "checkSum=$checkSum" \
-    "$PDS_SERVER/api/job/${jobUUID}/upload/sourcecode.zip" | $RESULT_FILTER
+    "$PDS_SERVER/api/job/${jobUUID}/upload/$upload_file_name" | $RESULT_FILTER
 
   if [[ "$?" == "0" ]] ; then
-    echo "File \"$zip_file\" uploaded."
+    echo "Uploaded file: \"$file_to_upload\""
   else
     echo "Upload failed."
   fi
@@ -223,10 +233,10 @@ case "$action" in
     JSON_FILE="$1" ; check_parameter JSON_FILE
     [ $FAILED == 0 ] && create_job_from_json "$JSON_FILE" 
     ;;
-  upload_zip)
+  upload)
     SECHUB_JOB_UUID="$1" ; check_parameter SECHUB_JOB_UUID
-    ZIP_FILE="$2" ; check_parameter ZIP_FILE
-    [ $FAILED == 0 ] && upload_zip "$SECHUB_JOB_UUID" "$ZIP_FILE" 
+    FILE_TO_UPLOAD="$2" ; check_parameter FILE_TO_UPLOAD
+    [ $FAILED == 0 ] && upload "$SECHUB_JOB_UUID" "$FILE_TO_UPLOAD" 
     ;;
   mark_job_ready_to_start)
     JOB_UUID="$1"   ; check_parameter JOB_UUID

--- a/sechub-pds-solutions/gosec/70-test.sh
+++ b/sechub-pds-solutions/gosec/70-test.sh
@@ -3,6 +3,7 @@
 
 file_to_upload="$1"
 json_config="$2"
+upload_type="source"
 
 function usage() {
     local script_name=
@@ -137,10 +138,10 @@ fi
 
 echo "Job created. Job UUID: $jobUUID"
 
-"$pds_api" upload_zip "$jobUUID" "$file_to_upload"
+echo "Uploading file: $file_to_upload"
+"$pds_api" upload "$jobUUID" "$file_to_upload"
 
 "$pds_api" mark_job_ready_to_start "$jobUUID"
-
 echo "Job $jobUUID marked as ready to start."
 
 # Check the status of the job

--- a/sechub-pds-solutions/scancode/docker/ScanCode-Ubuntu.dockerfile
+++ b/sechub-pds-solutions/scancode/docker/ScanCode-Ubuntu.dockerfile
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE}
 
 # Build args
 ARG PDS_FOLDER="/pds"
-ARG PDS_VERSION="0.27.0"
+ARG PDS_VERSION="0.29.0"
 ARG PYTHON_VERSION="3.9"
 ARG SCANCODE_VERSION="30.1.0"
 ARG SCANCODE_CHECKSUM="a9e43fdef934335e69e4abf77896225545d3e1fdbbd477ebabc37a4fa5ee2015  scancode-toolkit-30.1.0_py39-linux.tar.xz"
@@ -45,6 +45,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get --assume-yes upgrade  && \
     apt-get --assume-yes install wget \
                                  tar \
+                                 tree \
                                  openjdk-11-jre-headless \
                                  "python${PYTHON_VERSION}" \
                                  "python${PYTHON_VERSION}-distutils" \
@@ -111,8 +112,9 @@ WORKDIR "$WORKSPACE"
 # Switch from root to non-root user
 USER pds
 
-# Configure ScanCode
+# Configure Scancode
 RUN cd "$TOOL_FOLDER/scancode-toolkit-$SCANCODE_VERSION/" && \
-    ./configure
+    ./configure && \
+    ./scancode --help > /dev/null
 
 CMD ["/run.sh"]

--- a/sechub-pds-solutions/scancode/docker/pds-config.json
+++ b/sechub-pds-solutions/scancode/docker/pds-config.json
@@ -1,32 +1,43 @@
 {
-    "apiVersion" : "1.0",
-    "serverId" : "SCANCODE_TOOL_CLUSTER", 
-
-    "products" : [
+    "apiVersion": "1.0",
+    "serverId": "SCANCODE_TOOL_CLUSTER",
+    "products": [
         {
-            "id" : "PDS_SCANCODE",
-            "path" : "/scripts/scancode.sh",
-            "scanType" : "codeScan",
-            "description" : "Runs Scancode.",
-            "parameters" : {
-                "optional" : [
+            "id": "PDS_SCANCODE",
+            "path": "/scripts/scancode.sh",
+            "scanType": "licenseScan",
+            "description": "Runs Scancode.",
+            "parameters": {
+                "optional": [
                     {
-                        "key" : "scancode.output.format",
-                        "description" : "Parameter defining the ScanCode output format. Possible values are: json, json-pp, spdx-tv, spdx-json, spdx-rdf. Json-pp stands for json pretty printed. Default: spdx-json."
+                        "key": "scancode.output.format",
+                        "description": "Parameter defining the ScanCode output format. Possible values are: json, json-pp, spdx-tv, spdx-json, spdx-rdf. Json-pp stands for json pretty printed. Default: spdx-json."
+                    },
+                    {
+                        "key": "scancode.license.score",
+                        "description": "A natural number between 0 (low macht accuracy) and 100 (high match accuracy). Default 0."
+                    },
+                    {
+                        "key": "scancode.processes",
+                        "description": "The number of processes used by ScanCode. A \"good\" value is the number of CPUs minus 1 (more information: https://github.com/nexB/scancode-toolkit/issues/2980#issuecomment-1146583845). Default 1."
+                    },
+                    {
+                        "key": "extractcode.enabled",
+                        "description": "Extractcode is a helper tool, which extracts archives before scanning. Set it to `true` to enable it. Default: `false`."
                     }
                 ]
             }
         },
         {
-            "id" : "PDS_SCANCODE_MOCK",
-            "path" : "/scripts/scancode_mock.sh",
-            "scanType" : "codeScan",
-            "description" : "Runs ScanCode mock.",
-            "parameters" : {
-                "optional" : [
+            "id": "PDS_SCANCODE_MOCK",
+            "path": "/scripts/scancode_mock.sh",
+            "scanType": "licenseScan",
+            "description": "Runs ScanCode mock.",
+            "parameters": {
+                "optional": [
                     {
-                        "key" : "scancode.output.format",
-                        "description" : "Parameter defining the ScanCode output format. Possible values are: json, json-pp, spdx-tv, spdx-json, spdx-rdf. Json-pp stands for json pretty printed. Default: spdx-json."
+                        "key": "scancode.output.format",
+                        "description": "Parameter defining the ScanCode output format. Possible values are: json, json-pp, spdx-tv, spdx-json, spdx-rdf. Json-pp stands for json pretty printed. Default: spdx-json."
                     }
                 ]
             }


### PR DESCRIPTION
- added support for binaries to `pds-api.sh`
- test.sh now supports binaries
- added binary support to the scancode.sh script #1373
- added the ability to use extractcode, set the number of processors
  and set the match accuracy #1383

closes: #1373
closes: #1383