### PR TITLE
Fix 1419 ajaxspider no implementor

### DIFF
--- a/sechub-pds-solutions/owasp-zap/01-start-single-docker-compose.sh
+++ b/sechub-pds-solutions/owasp-zap/01-start-single-docker-compose.sh
@@ -16,5 +16,5 @@ else
 fi
 
 
-echo "Starting single Ubuntu container."
-docker-compose --file docker-compose_pds_owasp_zap_ubuntu.yaml up --build --remove-orphans
+echo "Starting single Debian container."
+docker-compose --file docker-compose_pds_owasp_zap_debian.yaml up --build --remove-orphans

--- a/sechub-pds-solutions/owasp-zap/05-start-single-sechub-network-docker-compose.sh
+++ b/sechub-pds-solutions/owasp-zap/05-start-single-sechub-network-docker-compose.sh
@@ -16,5 +16,5 @@ else
 fi
 
 
-echo "Starting single Ubuntu container."
-docker-compose --file docker-compose_pds_owasp_zap_ubuntu_external_network.yaml up --build --remove-orphans
+echo "Starting single Debian container."
+docker-compose --file docker-compose_pds_owasp_zap_debian_external_network.yaml up --build --remove-orphans

--- a/sechub-pds-solutions/owasp-zap/10-create-ubuntu-image.sh
+++ b/sechub-pds-solutions/owasp-zap/10-create-ubuntu-image.sh
@@ -4,7 +4,7 @@
 REGISTRY="$1"
 VERSION="$2"
 BASE_IMAGE="$3"  # optional
-DEFAULT_BASE_IMAGE="ubuntu:20.04"
+DEFAULT_BASE_IMAGE="debian:11-slim"
 
 usage() {
   cat - <<EOF
@@ -49,5 +49,5 @@ fi
 
 docker build --pull --no-cache $BUILD_ARGS \
        --tag "$REGISTRY:$VERSION" \
-       --file docker/Owasp-Zap-Ubuntu.dockerfile docker/
+       --file docker/Owasp-Zap-Debian.dockerfile docker/
 docker tag "$REGISTRY:$VERSION" "$REGISTRY:latest"

--- a/sechub-pds-solutions/owasp-zap/README.adoc
+++ b/sechub-pds-solutions/owasp-zap/README.adoc
@@ -47,10 +47,10 @@ The folder contains a start script which does the <<manual-setup, manual>> steps
 [NOTE]
 It is recommended to change the default passwords in the `.env` file to improve security. It is possible to change other values in the `.env` file as well. Any change requires a restart of the container.
 
-. Start container the Ubuntu container using https://docs.docker.com/compose/[Docker Compose]:
+. Start container the Debian container using https://docs.docker.com/compose/[Docker Compose]:
 +
 ----
-docker-compose --file docker-compose_pds_owasp_zap_ubuntu.yaml up --build
+docker-compose --file docker-compose_pds_owasp_zap_debian.yaml up --build
 ----
 
 ==== Together with SecHub
@@ -59,7 +59,7 @@ The container will be started and attached to the `sechub` Network.
 
 IMPORTANT: Make sure the SecHub container is running.
 
-. Start Ubuntu container:
+. Start Debian container:
 +
 ----
 ./05-start-single-sechub-network-docker-compose.sh
@@ -316,10 +316,10 @@ There are several configuration options available for the PDS+OWSAP-Zap `docker-
 
 This section contains information about how to troubleshoot PDS+OWSAP-Zap if something goes wrong.
 
-==== Access the Ubuntu container
+==== Access the Debian container
 
 ----
-docker exec -it pds-owasp-zap-ubuntu bash
+docker exec -it pds-owasp-zap-debian bash
 ----
 
 ==== Java Application Remote Debugging of PDS
@@ -348,18 +348,18 @@ Build container images and push them to registry to run PDS+OWSAP-Zap on virtual
 
 Build the container image.
 
-==== Ubuntu
+==== Debian
 
 . Using the default image: 
 +
 ----
-./10-create-ubuntu-image.sh my.registry.example.org/sechub/pds_owasp_zap v0.1
+./10-create-debian-image.sh my.registry.example.org/sechub/pds_owasp_zap v0.1
 ----
 
 . Using your own base image:
 +
 ----
-./10-create-ubuntu-image.sh my.registry.example.org/sechub/pds_owasp_zap v0.1 "my.registry.example.org/ubuntu:focal"
+./10-create-debian-image.sh my.registry.example.org/sechub/pds_owasp_zap v0.1 "my.registry.example.org/debian:11-slim"
 ----
 
 === Push Image to Registry

--- a/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_cluster.yaml
+++ b/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_cluster.yaml
@@ -5,9 +5,9 @@ services:
   pds-owasp-zap:
     build:
       args:
-        - BASE_IMAGE=ubuntu:22.04
+        - BASE_IMAGE=debian:11-slim
       context: docker/
-      dockerfile: Owasp-Zap-Ubuntu.dockerfile
+      dockerfile: Owasp-Zap-Debian.dockerfile
     env_file:
       - .env-cluster
     networks:

--- a/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_cluster_object_storage.yaml
+++ b/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_cluster_object_storage.yaml
@@ -5,9 +5,9 @@ services:
   pds-owasp-zap:
     build:
       args:
-        - BASE_IMAGE=ubuntu:22.04
+        - BASE_IMAGE=debian:11-slim
       context: docker/
-      dockerfile: Owasp-Zap-Ubuntu.dockerfile
+      dockerfile: Owasp-Zap-Debian.dockerfile
     env_file:
       - .env-cluster-object-storage
     networks:

--- a/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_debian.yaml
+++ b/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_debian.yaml
@@ -2,13 +2,13 @@
 
 version: "3"
 services:
-  pds-owasp-zap-ubuntu:
+  pds-owasp-zap-debian:
     build:
       args:
-        - BASE_IMAGE=ubuntu:22.04
+        - BASE_IMAGE=debian:11-slim
       context: docker/
-      dockerfile: Owasp-Zap-Ubuntu.dockerfile
-    container_name: pds-owasp-zap-ubuntu
+      dockerfile: Owasp-Zap-Debian.dockerfile
+    container_name: pds-owasp-zap-debian
     env_file:
       - .env
     ports:

--- a/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_debian_external_network.yaml
+++ b/sechub-pds-solutions/owasp-zap/docker-compose_pds_owasp_zap_debian_external_network.yaml
@@ -2,13 +2,13 @@
 
 version: "3"
 services:
-  pds-owasp-zap-ubuntu:
+  pds-owasp-zap-debian:
     build:
       args:
-        - BASE_IMAGE=ubuntu:22.04
+        - BASE_IMAGE=debian:11-slim
       context: docker/
-      dockerfile: Owasp-Zap-Ubuntu.dockerfile
-    container_name: pds-owasp-zap-ubuntu
+      dockerfile: Owasp-Zap-Debian.dockerfile
+    container_name: pds-owasp-zap-debian
     env_file:
       - .env
     networks:

--- a/sechub-pds-solutions/owasp-zap/docker/Owasp-Zap-Debian.dockerfile
+++ b/sechub-pds-solutions/owasp-zap/docker/Owasp-Zap-Debian.dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="SecHub FOSS Team"
 # Build args
 ARG OWASPZAP_VERSION="2.11.1"
 ARG OWASPZAP_CHECKSUM="abbfe9ad057b3511043a0f0317d5f91d914145ada5b102a5708f8af6a5e191f8"
-ARG PDS_VERSION="0.29.0"
+ARG PDS_VERSION="0.30.0"
 
 ARG JAVA_VERSION="11"
 ARG PDS_FOLDER="/pds"
@@ -37,7 +37,7 @@ RUN mkdir --parents "$PDS_FOLDER" "${SCRIPT_FOLDER}" "$TOOL_FOLDER" "$WORKSPACE"
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get upgrade --assume-yes && \
-    apt-get install --assume-yes wget openjdk-${JAVA_VERSION}-jre firefox && \
+    apt-get install --assume-yes wget openjdk-${JAVA_VERSION}-jre firefox-esr && \
     apt-get clean
 
 # Install OWASP ZAP

--- a/sechub-pds-solutions/owasp-zap/docker/zap-addons.txt
+++ b/sechub-pds-solutions/owasp-zap/docker/zap-addons.txt
@@ -5,4 +5,6 @@ https://github.com/zaproxy/zap-extensions/releases/download/spiderAjax-v23.7.0/s
 https://github.com/zaproxy/zap-extensions/releases/download/pscanrules-v40/pscanrules-release-40.zap
 https://github.com/zaproxy/zap-extensions/releases/download/retire-v0.12.0/retire-release-0.12.0.zap
 https://github.com/zaproxy/zap-extensions/releases/download/domxss-v12/domxss-beta-12.zap
+https://github.com/zaproxy/zap-extensions/releases/download/webdriverlinux-v40/webdriverlinux-release-40.zap
+https://github.com/zaproxy/zap-extensions/releases/download/network-v0.2.0/network-alpha-0.2.0.zap
 https://github.com/mercedes-benz/zap-extensions/releases/download/sarif-report-0.14.0/reports-release-0.14.0.zap

--- a/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/Chart.yaml
+++ b/sechub-pds-solutions/owasp-zap/helm/pds-owaspzap/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0


### PR DESCRIPTION
This PR:
-adds 2 extensions to the Owasp Zap required to use the ajax spider
-changes the base image from ubuntu to debian
-installs firefox-esr required for the ajax spider
-updates documentation and other parts from ubuntu to debian

- closes #1419 
- closes #1421 