### PR TITLE
Add authentication information to RestDoc Tests #1581

### DIFF
--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/AdminShowsScanLogsForProjectRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/AdminShowsScanLogsForProjectRestDocTest.java
@@ -6,6 +6,8 @@ import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -90,8 +92,9 @@ public class AdminShowsScanLogsForProjectRestDocTest implements TestIsNecessaryF
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				get(apiEndpoint,PROJECT1).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+				  get(apiEndpoint,PROJECT1).
+				  contentType(MediaType.APPLICATION_JSON_VALUE).
+				  header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -101,7 +104,10 @@ public class AdminShowsScanLogsForProjectRestDocTest implements TestIsNecessaryF
                     responseSchema(OpenApiSchema.PROJECT_SCAN_LOGS.getSchema()).
                 and().
                 document(
-				/* we do not document more, because its binary / zip file...*/
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
+                			/* we do not document more, because its binary / zip file...*/
                             responseFields(
                                     fieldWithPath("[]").description("An array of scan log summary entries"),
                                     fieldWithPath("[].executedBy").description("The user id of the user which executed the scan"),
@@ -112,7 +118,7 @@ public class AdminShowsScanLogsForProjectRestDocTest implements TestIsNecessaryF
                             ),
                             pathParameters(
                                     parameterWithName(PROJECT_ID.paramName()).description("The project Id")
-                         )
+                            )
 				    ));
 
 		/* @formatter:on */

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/AuthenticationHelper.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/AuthenticationHelper.java
@@ -1,0 +1,15 @@
+package com.mercedesbenz.sechub.restdoc;
+
+import java.util.Base64;
+
+public class AuthenticationHelper {
+    public static final String HEADER_NAME = "Authorization";
+    public static final String HEADER_DESCRIPTION = "Basic authentication credentials";
+    private static final String USER_TOKEN = "user:secret";
+
+    public static String getHeaderValue() {
+        String userAndTokenEncoded = Base64.getEncoder().encodeToString(USER_TOKEN.getBytes());
+
+        return "Basic " + userAndTokenEncoded;
+    }
+}

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ConfigAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ConfigAdministrationRestControllerRestDocTest.java
@@ -4,6 +4,8 @@ package com.mercedesbenz.sechub.restdoc;
 import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -71,9 +73,10 @@ public class ConfigAdministrationRestControllerRestDocTest implements TestIsNece
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				put(apiEndpoint).
-				content(config.toJSON()).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					put(apiEndpoint).
+					content(config.toJSON()).
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isAccepted()).
 		andDo(defineRestService().
@@ -81,8 +84,11 @@ public class ConfigAdministrationRestControllerRestDocTest implements TestIsNece
                     useCaseData(useCase).
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
-                document()
-        );
+                document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		)
+                ));
 		/* @formatter:on */
     }
 
@@ -98,8 +104,9 @@ public class ConfigAdministrationRestControllerRestDocTest implements TestIsNece
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				get(apiEndpoint).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					get(apiEndpoint).
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andExpect(content().json(config.toJSON())).
@@ -108,8 +115,11 @@ public class ConfigAdministrationRestControllerRestDocTest implements TestIsNece
                     useCaseData(useCase).
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
-                document()
-        );
+                document(
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		)
+        ));
 		/* @formatter:on */
     }
 

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/DownloadsFullScanDataForJobRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/DownloadsFullScanDataForJobRestDocTest.java
@@ -5,6 +5,8 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -100,8 +102,9 @@ public class DownloadsFullScanDataForJobRestDocTest implements TestIsNecessaryFo
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				get(apiEndpoint,jobUUID).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					get(apiEndpoint,jobUUID).
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -111,6 +114,9 @@ public class DownloadsFullScanDataForJobRestDocTest implements TestIsNecessaryFo
                     responseSchema(OpenApiSchema.FULL_SCAN_DATA_ZIP.getSchema()).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(JOB_UUID.paramName()).description("The job UUID")
                 )

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/FalsePositiveRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/FalsePositiveRestControllerRestDocTest.java
@@ -8,6 +8,8 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -126,9 +128,11 @@ public class FalsePositiveRestControllerRestDocTest implements TestIsNecessaryFo
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				put(apiEndpoint, PROJECT1_ID).
-		contentType(MediaType.APPLICATION_JSON_VALUE).
-        content(content)).
+			put(apiEndpoint, PROJECT1_ID).
+			contentType(MediaType.APPLICATION_JSON_VALUE).
+	        content(content).
+	        header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+        ).
 		andExpect(status().isOk()).
 		/*andDo(print()).*/
 		andDo(defineRestService().
@@ -138,6 +142,9 @@ public class FalsePositiveRestControllerRestDocTest implements TestIsNecessaryFo
                     requestSchema(OpenApiSchema.FALSE_POSITVES_FOR_JOB.getSchema()).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             requestFields(
                                     fieldWithPath(PROPERTY_API_VERSION).description("The api version, currently only 1.0 is supported"),
                                     fieldWithPath(PROPERTY_TYPE).description("The type of the json content. Currently only accepted value is '"+FalsePositiveJobDataList.ACCEPTED_TYPE+"'."),
@@ -168,7 +175,8 @@ public class FalsePositiveRestControllerRestDocTest implements TestIsNecessaryFo
 
         /* execute + test @formatter:off */
         this.mockMvc.perform(
-                delete(apiEndpoint,PROJECT1_ID,jobUUID,findingId)
+                delete(apiEndpoint,PROJECT1_ID,jobUUID,findingId).
+                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         ).
         andExpect(status().isOk()).
         /*andDo(print()).*/
@@ -178,6 +186,9 @@ public class FalsePositiveRestControllerRestDocTest implements TestIsNecessaryFo
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(PROJECT_ID.paramName()).description("The project id"),
                                     parameterWithName(JOB_UUID.paramName()).description("Job uuid"),
@@ -239,7 +250,8 @@ public class FalsePositiveRestControllerRestDocTest implements TestIsNecessaryFo
         String codeMetaDataPath = metaDataPath+"."+FalsePositiveMetaData.PROPERTY_CODE;
 
         this.mockMvc.perform(
-                get(apiEndpoint,PROJECT1_ID)
+                get(apiEndpoint,PROJECT1_ID).
+                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         ).
         andExpect(status().isOk()).
         /*andDo(print()).*/
@@ -250,6 +262,9 @@ public class FalsePositiveRestControllerRestDocTest implements TestIsNecessaryFo
                     responseSchema(OpenApiSchema.FALSE_POSITVES.getSchema()).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             responseFields(
                                     fieldWithPath(PROPERTY_FALSE_POSITIVES).description("Job data list containing false positive setup based on former jobs"),
                                     fieldWithPath(PROPERTY_FALSE_POSITIVES+"[]."+FalsePositiveEntry.PROPERTY_AUTHOR).description("User id of author who created false positive"),

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/JobAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/JobAdministrationRestControllerRestDocTest.java
@@ -5,6 +5,8 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -97,11 +99,10 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				get(apiEndpoint).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
-				)./*
-		andDo(print()).
-				*/
+					get(apiEndpoint).
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
                 with().
@@ -110,14 +111,17 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
                     responseSchema(OpenApiSchema.RUNNING_JOB_LIST.getSchema()).
                 and().
                 document(
-                            responseFields(
-                                    fieldWithPath(inArray(JobInformation.PROPERTY_JOB_UUID)).description("The uuid of the running job"),
-                                    fieldWithPath(inArray(JobInformation.PROPERTY_PROJECT_ID)).description("The name of the project the job is running for"),
-                                    fieldWithPath(inArray(JobInformation.PROPERTY_OWNER)).description("Owner of the job - means user which triggered it"),
-                                    fieldWithPath(inArray(JobInformation.PROPERTY_STATUS)).description("A status information "),
-                                    fieldWithPath(inArray(JobInformation.PROPERTY_SINCE)).description("Timestamp since when job has been started"),
-                                    fieldWithPath(inArray(JobInformation.PROPERTY_CONFIGURATION)).description("Configuration used for this job")
-                         )
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
+	                        responseFields(
+	                                    fieldWithPath(inArray(JobInformation.PROPERTY_JOB_UUID)).description("The uuid of the running job"),
+	                                    fieldWithPath(inArray(JobInformation.PROPERTY_PROJECT_ID)).description("The name of the project the job is running for"),
+	                                    fieldWithPath(inArray(JobInformation.PROPERTY_OWNER)).description("Owner of the job - means user which triggered it"),
+	                                    fieldWithPath(inArray(JobInformation.PROPERTY_STATUS)).description("A status information "),
+	                                    fieldWithPath(inArray(JobInformation.PROPERTY_SINCE)).description("Timestamp since when job has been started"),
+	                                    fieldWithPath(inArray(JobInformation.PROPERTY_CONFIGURATION)).description("Configuration used for this job")
+	                         )
 				));
 
 		/* @formatter:on */
@@ -134,11 +138,10 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
 		UUID jobUUID = UUID.randomUUID();
 
 		this.mockMvc.perform(
-				post(apiEndpoint, jobUUID).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
-				)./*
-		andDo(print()).
-				*/
+					post(apiEndpoint, jobUUID).
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
                 with().
@@ -146,9 +149,12 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
-                            pathParameters(
-                                    parameterWithName(JOB_UUID.paramName()).description("The job UUID")
-                         )
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
+                        pathParameters(
+                                parameterWithName(JOB_UUID.paramName()).description("The job UUID")
+                        )
 		        ));
 
 		/* @formatter:on */
@@ -165,11 +171,10 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
         UUID jobUUID = UUID.randomUUID();
 
         this.mockMvc.perform(
-                post(apiEndpoint, jobUUID).
-                contentType(MediaType.APPLICATION_JSON_VALUE)
-                )./*
-        andDo(print()).
-                */
+	                post(apiEndpoint, jobUUID).
+	                contentType(MediaType.APPLICATION_JSON_VALUE).
+	                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+                ).
         andExpect(status().isOk()).
         andDo(defineRestService().
                 with().
@@ -177,7 +182,10 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
-                            pathParameters(
+                		 requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		 ),
+                         pathParameters(
                                     parameterWithName(JOB_UUID.paramName()).description("The job UUID")
                          )
                 ));
@@ -196,11 +204,10 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
         UUID jobUUID = UUID.randomUUID();
 
         this.mockMvc.perform(
-                post(apiEndpoint,jobUUID).
-                contentType(MediaType.APPLICATION_JSON_VALUE)
-                )./*
-        andDo(print()).
-                */
+	                post(apiEndpoint,jobUUID).
+	                contentType(MediaType.APPLICATION_JSON_VALUE).
+	                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+                ).
         andExpect(status().isOk()).
         andDo(defineRestService().
                 with().
@@ -208,9 +215,12 @@ public class JobAdministrationRestControllerRestDocTest implements TestIsNecessa
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
-                            pathParameters(
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
+                        pathParameters(
                                     parameterWithName(JOB_UUID.paramName()).description("The job UUID")
-                         )
+                        )
               ));
 
         /* @formatter:on */

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/MappingAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/MappingAdministrationRestControllerRestDocTest.java
@@ -4,6 +4,8 @@ package com.mercedesbenz.sechub.restdoc;
 import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -94,10 +96,10 @@ public class MappingAdministrationRestControllerRestDocTest implements TestIsNec
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				get(apiEndpoint).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
-				)./*
-				*/
+					get(apiEndpoint).
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+				).
 		andDo(print()).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -107,6 +109,9 @@ public class MappingAdministrationRestControllerRestDocTest implements TestIsNec
                     responseSchema(OpenApiSchema.STATUS_INFORMATION.getSchema()).
                 and().
                 document(
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
                             responseFields(
                                     fieldWithPath("[]."+StatusEntry.PROPERTY_KEY).description("Status key identifier"),
                                     fieldWithPath("[]."+StatusEntry.PROPERTY_VALUE).description("Status value")

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProductExecutionProfileRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProductExecutionProfileRestControllerRestDocTest.java
@@ -6,6 +6,8 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -122,7 +124,8 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
 	    this.mockMvc.perform(
 	    		post(apiEndpoint, profileId).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
-	    			content(JSONConverter.get().toJSON(profile))
+	    			content(JSONConverter.get().toJSON(profile)).
+	    			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 	    		).
 	    			andExpect(status().isCreated()).
 	    			andDo(defineRestService().
@@ -132,6 +135,9 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
                                 requestSchema(OpenApiSchema.EXECUTION_PROFILE_CREATE.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         requestFields(
                                                 fieldWithPath(PROPERTY_DESCRIPTION).description("A short description for the profile"),
                                                 fieldWithPath(PROPERTY_ENABLED).description("Enabled state of profile, default is false").optional(),
@@ -170,7 +176,8 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
         this.mockMvc.perform(
                 put(apiEndpoint, profileId).
                     contentType(MediaType.APPLICATION_JSON_VALUE).
-                    content(JSONConverter.get().toJSON(profile))
+                    content(JSONConverter.get().toJSON(profile)).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -180,6 +187,9 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
                                 requestSchema(OpenApiSchema.EXECUTION_PROFILE_UPDATE.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         requestFields(
                                                 fieldWithPath(PROPERTY_DESCRIPTION).description("A short description for the profile"),
                                                 fieldWithPath(PROPERTY_ENABLED).description("Enabled state of profile, default is false").optional(),
@@ -210,8 +220,9 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
 
         /* execute + test @formatter:off */
         this.mockMvc.perform(
-                post(apiEndpoint, profileId,projectId).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
+                	post(apiEndpoint, profileId,projectId).
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isCreated()).
                     andDo(defineRestService().
@@ -220,10 +231,13 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
-                                        pathParameters(
-                                                parameterWithName(PROJECT_ID.paramName()).description("The project id "),
-                                                parameterWithName(PROFILE_ID.paramName()).description("The profile id")
-                                     )
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
+	                                    pathParameters(
+	                                                parameterWithName(PROJECT_ID.paramName()).description("The project id "),
+	                                                parameterWithName(PROFILE_ID.paramName()).description("The profile id")
+	                                    )
                     ));
 
         /* @formatter:on */
@@ -242,8 +256,9 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 delete(apiEndpoint, profileId,projectId).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
-                )./*andDo(print()).*/
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+                ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
                             with().
@@ -251,10 +266,13 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The project id "),
                                                 parameterWithName(PROFILE_ID.paramName()).description("The profile id")
-                                     )
+                                        )
                     ));
 
         /* @formatter:on */
@@ -299,7 +317,8 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 get(apiEndpoint, profileId).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -309,6 +328,9 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
                                 responseSchema(OpenApiSchema.EXECUTION_PROFILE_FETCH.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         responseFields(
                                                 fieldWithPath(PROPERTY_ID).optional().ignored(),
                                                 fieldWithPath(PROPERTY_DESCRIPTION).description("A short description for the profile"),
@@ -344,7 +366,8 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
 	    String profileId= "profile-to-delete-1";
 	    this.mockMvc.perform(
                 delete(apiEndpoint, profileId).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -353,9 +376,12 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         pathParameters(
                                                 parameterWithName(PROFILE_ID.paramName()).description("The profile id")
-                                     )
+                                        )
                             ));
 
         /* @formatter:on */
@@ -387,7 +413,8 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 get(apiEndpoint).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -397,12 +424,15 @@ public class ProductExecutionProfileRestControllerRestDocTest implements TestIsN
                                 responseSchema(OpenApiSchema.EXECUTION_PROFILE_LIST.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         responseFields(
                                                 fieldWithPath("type").description("Always `executorProfileList` as an identifier for the list"),
                                                 fieldWithPath("executionProfiles[]."+PROPERTY_ID).description("The profile id"),
                                                 fieldWithPath("executionProfiles[]."+PROPERTY_DESCRIPTION).description("A profile description"),
                                                 fieldWithPath("executionProfiles[]."+PROPERTY_ENABLED).description("Enabled state of profile")
-                                     )
+                                        )
                             ));
 
         /* @formatter:on */

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProductExecutorConfigRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProductExecutorConfigRestControllerRestDocTest.java
@@ -7,6 +7,8 @@ import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -136,7 +138,8 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
 	    this.mockMvc.perform(
 	    		post(apiEndpoint).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
-	    			content(JSONConverter.get().toJSON(configFromUser))
+	    			content(JSONConverter.get().toJSON(configFromUser)).
+	    			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 	    		).
 	    			andExpect(status().isCreated()).
 	    			andExpect(content().string(randomUUID.toString())).
@@ -148,6 +151,9 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
                                 requestSchema(OpenApiSchema.EXECUTOR_CONFIGURATION.getSchema()).
                             and().
                             document(
+		    	                		requestHeaders(
+		    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+		    	                		),
 	                                    requestFields(
 	                                            fieldWithPath(PROPERTY_NAME).description("A name for this configuration"),
 	                                            fieldWithPath(PROPERTY_PRODUCTIDENTIFIER).description("Executor product identifier"),
@@ -190,7 +196,8 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
         this.mockMvc.perform(
                 put(apiEndpoint,randomUUID).
                     contentType(MediaType.APPLICATION_JSON_VALUE).
-                    content(JSONConverter.get().toJSON(configFromUser))
+                    content(JSONConverter.get().toJSON(configFromUser)).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -200,6 +207,9 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
                                 requestSchema(OpenApiSchema.EXECUTOR_CONFIGURATION.getSchema()).
                             and().
                             document(
+		    	                		requestHeaders(
+		    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+		    	                		),
                                         requestFields(
                                                 fieldWithPath(PROPERTY_NAME).description("The name of this configuration"),
                                                 fieldWithPath(PROPERTY_PRODUCTIDENTIFIER).description("Executor product identifier"),
@@ -248,7 +258,8 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 get(apiEndpoint,uuid).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -258,6 +269,9 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
                                 responseSchema(OpenApiSchema.EXECUTOR_CONFIGURATION_WITH_UUID.getSchema()).
                             and().
                             document(
+		    	                		requestHeaders(
+		    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+		    	                		),
                                         responseFields(
                                                 fieldWithPath(PROPERTY_UUID).description("The uuid of this configuration"),
                                                 fieldWithPath(PROPERTY_NAME).description("The name of this configuration"),
@@ -289,7 +303,8 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
 	    UUID configUUID = UUID.randomUUID();
         this.mockMvc.perform(
                 delete(apiEndpoint, configUUID).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -298,8 +313,11 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
-                                        pathParameters(
-                                                parameterWithName(UUID_PARAMETER.paramName()).description("The configuration uuid")
+	    	                		 requestHeaders(
+	    	                				 headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	    	                		 ),
+                                     pathParameters(
+                                    		 parameterWithName(UUID_PARAMETER.paramName()).description("The configuration uuid")
                                      )
                             ));
 
@@ -324,7 +342,8 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 get(apiEndpoint).
-                    contentType(MediaType.APPLICATION_JSON_VALUE)
+                    contentType(MediaType.APPLICATION_JSON_VALUE).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                     andDo(defineRestService().
@@ -334,6 +353,9 @@ public class ProductExecutorConfigRestControllerRestDocTest implements TestIsNec
                                 responseSchema(OpenApiSchema.EXECUTOR_CONFIGURATION_LIST.getSchema()).
                             and().
                             document(
+		    	                		requestHeaders(
+		    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+		    	                		),
                                         responseFields(
                                                 fieldWithPath("type").description("Always `executorConfigurationList` as an identifier for the list"),
                                                 fieldWithPath("executorConfigurations[]."+PROPERTY_UUID).description("The uuid of the configuration"),

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProjectAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProjectAdministrationRestControllerRestDocTest.java
@@ -6,6 +6,8 @@ import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -141,13 +143,14 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				post(apiEndpoint).
-				contentType(MediaType.APPLICATION_JSON_VALUE).
-				content("{\"apiVersion\":\"1.0\", "
-				        + "\"name\":\"projectId\", "
-				        + "\"description\":\"A description of the project.\", "
-				        + "\"owner\":\"ownerName1\", "
-				        + "\"whiteList\":{\"uris\":[\"192.168.1.1\",\"https://my.special.server.com/myapp1/\"]}, "
-				        + "\"metaData\":{\"key1\":\"value1\", \"key2\":\"value2\"}}")
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					content("{\"apiVersion\":\"1.0\", "
+					        + "\"name\":\"projectId\", "
+					        + "\"description\":\"A description of the project.\", "
+					        + "\"owner\":\"ownerName1\", "
+					        + "\"whiteList\":{\"uris\":[\"192.168.1.1\",\"https://my.special.server.com/myapp1/\"]}, "
+					        + "\"metaData\":{\"key1\":\"value1\", \"key2\":\"value2\"}}")
 				).
 		andExpect(status().isCreated()).
 		andDo(defineRestService().
@@ -157,6 +160,9 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     requestSchema(OpenApiSchema.PROJECT.getSchema()).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             requestFields(
                                     fieldWithPath(ProjectJsonInput.PROPERTY_API_VERSION).description("The api version, currently only 1.0 is supported"),
                                     fieldWithPath(ProjectJsonInput.PROPERTY_NAME).description("Name of the project to create. Is also used as a unique ID!"),
@@ -185,21 +191,26 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         when(listProjectsService.listProjects()).thenReturn(ids);
 
         /* execute + test @formatter:off */
-        this.mockMvc.perform(
-        		get(apiEndpoint).
-        		contentType(MediaType.APPLICATION_JSON_VALUE)).
-                    andExpect(status().isOk()).
-                    andDo(defineRestService().
-                            with().
-                                useCaseData(useCase).
-                                tag(RestDocFactory.extractTag(apiEndpoint)).
-                                responseSchema(OpenApiSchema.PROJECT_LIST.getSchema()).
-                            and().
-                            document(
-        	                            responseFields(
-        	                                    fieldWithPath("[]").description("List of project Ids").optional()
-        	                         )
-        			        ));
+		this.mockMvc
+				.perform(
+						get(apiEndpoint).
+							header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
+							contentType(MediaType.APPLICATION_JSON_VALUE))
+				.andExpect(status().isOk())
+				.andDo(defineRestService().
+						with().
+							useCaseData(useCase).
+							tag(RestDocFactory.extractTag(apiEndpoint)).
+							responseSchema(OpenApiSchema.PROJECT_LIST.getSchema()).
+						and().
+						document(
+								requestHeaders(
+										headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+								),
+								responseFields(
+										fieldWithPath("[]").description("List of project Ids").optional()
+								)
+				));
 
 		/* @formatter:on */
     }
@@ -214,7 +225,8 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				delete(apiEndpoint,"projectId1").
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -223,9 +235,12 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(PROJECT_ID.paramName()).description("The id for project to delete")
-                         )
+                            )
 				));
 		/* @formatter:on */
     }
@@ -240,7 +255,8 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 post(apiEndpoint, "projectId1", "userId1").
-                contentType(MediaType.APPLICATION_JSON_VALUE)
+	                contentType(MediaType.APPLICATION_JSON_VALUE).
+	                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
         andExpect(status().isOk()).
         andDo(defineRestService().
@@ -249,10 +265,13 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(PROJECT_ID.paramName()).description("The id for project"),
                                     parameterWithName(USER_ID.paramName()).description("The user id of the user to assign to project as the owner")
-                         )
+                            )
                 ));
         /* @formatter:on */
     }
@@ -284,7 +303,8 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 post(apiEndpoint, "projectId1", ProjectAccessLevel.READ_ONLY.getId()).
-                contentType(MediaType.APPLICATION_JSON_VALUE)
+	                contentType(MediaType.APPLICATION_JSON_VALUE).
+	                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
         andExpect(status().isOk()).
         andDo(defineRestService().
@@ -293,10 +313,13 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
-                pathParameters(
-                        parameterWithName(PROJECT_ID.paramName()).description("The id for project"),
-                        parameterWithName(PROJECT_ACCESS_LEVEL.paramName()).description("The new project access level. "+acceptedValues.toString())
-                        )
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
+		                pathParameters(
+		                        parameterWithName(PROJECT_ID.paramName()).description("The id for project"),
+		                        parameterWithName(PROJECT_ACCESS_LEVEL.paramName()).description("The new project access level. "+acceptedValues.toString())
+		                )
                 ));
 
         /* @formatter:on */
@@ -312,7 +335,8 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				post(apiEndpoint, "projectId1", "userId1").
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -321,10 +345,13 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(PROJECT_ID.paramName()).description("The id for project"),
                                     parameterWithName(USER_ID.paramName()).description("The user id of the user to assign to project")
-                         )
+                            )
 				));
 
 		/* @formatter:on */
@@ -340,7 +367,8 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				delete(apiEndpoint,"userId1", "projectId1").
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -349,10 +377,13 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(PROJECT_ID.paramName()).description("The id for project"),
                                     parameterWithName(USER_ID.paramName()).description("The user id of the user to unassign from project")
-                         )
+                            )
 				));
 
 		/* @formatter:on */
@@ -402,7 +433,8 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				get(apiEndpoint,"projectId1").
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 		).
 		andDo(print()).
 		andExpect(status().isOk()).
@@ -413,9 +445,12 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     responseSchema(OpenApiSchema.PROJECT_DETAILS.getSchema()).
                 and().
                 document(
+                		requestHeaders(
+                			headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
                         pathParameters(
 							parameterWithName(PROJECT_ID.paramName()).description("The id for project to show details for")
-                            ),
+                        ),
                         responseFields(
                             fieldWithPath(ProjectDetailInformation.PROPERTY_PROJECT_ID).description("The name of the project"),
                             fieldWithPath(ProjectDetailInformation.PROPERTY_USERS).description("A list of all users having access to the project"),
@@ -473,10 +508,11 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 post(apiEndpoint, "projectId1").
-                content("{\n"
-                        + "  \"description\" : \"new description\"\n"
-                        + "}").
-                contentType(MediaType.APPLICATION_JSON_VALUE)
+	                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
+	                content("{\n"
+	                        + "  \"description\" : \"new description\"\n"
+	                        + "}").
+	                contentType(MediaType.APPLICATION_JSON_VALUE)
                 )./*
                 */
         andDo(print()).
@@ -488,9 +524,12 @@ public class ProjectAdministrationRestControllerRestDocTest implements TestIsNec
                     responseSchema(OpenApiSchema.PROJECT_DETAILS.getSchema()).
                 and().
                 document(
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
                         pathParameters(
                             parameterWithName(PROJECT_ID.paramName()).description("The id for project to change details for")
-                            ),
+                        ),
                         responseFields(
                             fieldWithPath(ProjectDetailInformation.PROPERTY_PROJECT_ID).description("The name of the project."),
                             fieldWithPath(ProjectDetailInformation.PROPERTY_USERS).description("A list of all users having access to the project."),

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProjectUpdateAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ProjectUpdateAdministrationRestControllerRestDocTest.java
@@ -5,6 +5,8 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -87,6 +89,7 @@ public class ProjectUpdateAdministrationRestControllerRestDocTest implements Tes
         /* execute + test @formatter:off */
         this.mockMvc.perform(
         		    post(apiEndpoint, "projectId1").
+        		    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
         		    contentType(MediaType.APPLICATION_JSON_VALUE).
         		    content("{\"apiVersion\":\"1.0\", \"whiteList\":{\"uris\":[\"192.168.1.1\",\"https://my.special.server.com/myapp1/\"]}}")
         		).
@@ -98,6 +101,9 @@ public class ProjectUpdateAdministrationRestControllerRestDocTest implements Tes
                                  requestSchema(OpenApiSchema.PROJECT_WHITELIST.getSchema()).
                              and().
                              document(
+		    	                		requestHeaders(
+		    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+		    	                		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The id of the project for which whitelist shall be updated")
                                         ),
@@ -120,6 +126,7 @@ public class ProjectUpdateAdministrationRestControllerRestDocTest implements Tes
         /* execute + test @formatter:off */
         this.mockMvc.perform(
         		post(apiEndpoint, "projectId1").
+        				header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
         				contentType(MediaType.APPLICATION_JSON_VALUE).
         				content("{\"apiVersion\":\"1.0\", \"metaData\":{\"key1\":\"value1\"}}")
         		).
@@ -131,6 +138,9 @@ public class ProjectUpdateAdministrationRestControllerRestDocTest implements Tes
                             requestSchema(OpenApiSchema.PROJECT_META_DATA.getSchema()).
                         and().
                         document(
+	    	                		requestHeaders(
+	    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	    	                		),
                                     pathParameters(
                                             parameterWithName(PROJECT_ID.paramName()).description("The id of the project for which metadata shall be updated")
                                     ),

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ScanProjectMockDataRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ScanProjectMockDataRestControllerRestDocTest.java
@@ -4,6 +4,8 @@ package com.mercedesbenz.sechub.restdoc;
 import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -72,12 +74,13 @@ public class ScanProjectMockDataRestControllerRestDocTest implements TestIsNeces
         config.setInfraScan(new ScanMockData(TrafficLight.GREEN));
 
         /* @formatter:off */
-		/* execute + test @formatter:off */
+		/* execute + test */
 	    this.mockMvc.perform(
 	    		put(apiEndpoint,PROJECT1_ID).
 	    			accept(MediaType.APPLICATION_JSON_VALUE).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
-	    			content(config.toJSON())
+	    			content(config.toJSON()).
+	    			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 	    		).
 	    			andExpect(status().isOk()).
 	    			andDo(defineRestService().
@@ -86,8 +89,11 @@ public class ScanProjectMockDataRestControllerRestDocTest implements TestIsNeces
 	    	                    tag(RestDocFactory.extractTag(apiEndpoint)).
 	    	                    requestSchema(OpenApiSchema.MOCK_DATA_CONFIGURATION.getSchema()).
 	    	                and().
-	    	                document()
-	    			);
+	    	                document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		)
+	    			));
 	    /* @formatter:on */
     }
 
@@ -111,7 +117,8 @@ public class ScanProjectMockDataRestControllerRestDocTest implements TestIsNeces
         this.mockMvc.perform(
         		get(apiEndpoint, PROJECT1_ID).
         			accept(MediaType.APPLICATION_JSON_VALUE).
-        			contentType(MediaType.APPLICATION_JSON_VALUE)
+        			contentType(MediaType.APPLICATION_JSON_VALUE).
+        			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isOk()).
         			andExpect(jsonPath("$.codeScan.result").value("RED")).
@@ -124,7 +131,11 @@ public class ScanProjectMockDataRestControllerRestDocTest implements TestIsNeces
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                                 responseSchema(OpenApiSchema.MOCK_DATA_CONFIGURATION.getSchema()).
                             and().
-                            document()
+                            document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		)
+                            		)
                     );
 
         /* @formatter:on */

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ScanReportRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ScanReportRestControllerRestDocTest.java
@@ -7,6 +7,8 @@ import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -97,7 +99,8 @@ public class ScanReportRestControllerRestDocTest implements TestIsNecessaryForDo
 	    this.mockMvc.perform(
 	    		get(apiEndpoint,PROJECT1_ID,jobUUID).
 	    		    accept(MediaType.APPLICATION_JSON_VALUE).
-	    			contentType(MediaType.APPLICATION_JSON_VALUE)
+	    			contentType(MediaType.APPLICATION_JSON_VALUE).
+	    			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 	    		).
 	    			andExpect(status().isOk()).
 	    			andExpect(content().json("{\"jobUUID\":\""+jobUUID.toString()+"\",\"result\":{\"count\":0,\"findings\":[]},\"trafficLight\":\"YELLOW\"}")).
@@ -108,10 +111,13 @@ public class ScanReportRestControllerRestDocTest implements TestIsNecessaryForDo
                                 responseSchema(OpenApiSchema.SECHUB_REPORT.getSchema()).
                             and().
                             document(
-                                        pathParameters(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
+                                    	pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The project Id"),
                                                 parameterWithName(JOB_UUID.paramName()).description("The job UUID")
-                                    )
+                                    	)
 	    			     ));
 
 	    /* @formatter:on */
@@ -142,7 +148,8 @@ public class ScanReportRestControllerRestDocTest implements TestIsNecessaryForDo
         this.mockMvc.perform(
         		get(apiEndpoint,PROJECT1_ID,jobUUID).
         		    accept(MediaType.APPLICATION_XHTML_XML).
-        			contentType(MediaType.APPLICATION_JSON_VALUE)
+        			contentType(MediaType.APPLICATION_JSON_VALUE).
+        			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isOk()).
         			andExpect(content().contentType("text/html;charset=UTF-8")).
@@ -156,10 +163,13 @@ public class ScanReportRestControllerRestDocTest implements TestIsNecessaryForDo
                                 responseSchema(OpenApiSchema.SECHUB_REPORT.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The project Id"),
                                                 parameterWithName(JOB_UUID.paramName()).description("The job UUID")
-                                    )
+                                        )
         			      ));
 
         /* @formatter:on */
@@ -187,7 +197,8 @@ public class ScanReportRestControllerRestDocTest implements TestIsNecessaryForDo
 	    this.mockMvc.perform(
 	    		get(apiEndpoint,PROJECT1_ID,jobUUID).
 	    		    accept(MediaType.APPLICATION_JSON_VALUE).
-	    			contentType(MediaType.APPLICATION_JSON_VALUE)
+	    			contentType(MediaType.APPLICATION_JSON_VALUE).
+	    			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 	    		).
 	    			andExpect(status().isOk()).
 	    			andExpect(content().json(spdxReport)).
@@ -198,10 +209,13 @@ public class ScanReportRestControllerRestDocTest implements TestIsNecessaryForDo
                                 responseSchema(OpenApiSchema.SECHUB_REPORT.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The project Id"),
                                                 parameterWithName(JOB_UUID.paramName()).description("The job UUID")
-                                    )
+                                        )
 	    			     ));
 
 	    /* @formatter:on */

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/SchedulerAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/SchedulerAdministrationRestControllerRestDocTest.java
@@ -3,6 +3,8 @@ package com.mercedesbenz.sechub.restdoc;
 
 import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -72,7 +74,8 @@ public class SchedulerAdministrationRestControllerRestDocTest implements TestIsN
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				post(apiEndpoint).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isAccepted()).
 		andDo(defineRestService().
@@ -80,7 +83,11 @@ public class SchedulerAdministrationRestControllerRestDocTest implements TestIsN
                     useCaseData(useCase).
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
-                document()
+                document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		)
+                		)
 		);
 		/* @formatter:on */
     }
@@ -95,7 +102,8 @@ public class SchedulerAdministrationRestControllerRestDocTest implements TestIsN
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				post(apiEndpoint).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isAccepted()).
 		andDo(defineRestService().
@@ -103,7 +111,11 @@ public class SchedulerAdministrationRestControllerRestDocTest implements TestIsN
                     useCaseData(useCase).
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
-                document()
+                document(
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		)
+                )
 		);
 		/* @formatter:on */
     }
@@ -118,7 +130,8 @@ public class SchedulerAdministrationRestControllerRestDocTest implements TestIsN
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				post(https(PORT_USED).buildAdminEnablesSchedulerJobProcessing()).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isAccepted()).
 		andDo(defineRestService().
@@ -126,7 +139,11 @@ public class SchedulerAdministrationRestControllerRestDocTest implements TestIsN
                     useCaseData(useCase).
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
-                document()
+                document(
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		)
+                )
         );
 		/* @formatter:on */
     }

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/SchedulerRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/SchedulerRestControllerRestDocTest.java
@@ -147,6 +147,7 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
 	    this.mockMvc.perform(
 	    		post(apiEndpoint,PROJECT1_ID).
+                	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
 	    			content(configureSecHub().
 	    					api("1.0").
@@ -166,6 +167,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
 	    	                    responseSchema(OpenApiSchema.JOB_ID.getSchema()).
 	    	                and().
 	    	                document(
+				    	                		requestHeaders(
+				    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+				    	                		),
 	    			                            pathParameters(
 	    			                                    parameterWithName(PROJECT_ID.paramName()).description("The unique id of the project id where a new sechub job shall be created")
 	    			                            ),
@@ -200,6 +204,7 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
 	    this.mockMvc.perform(
 	    		post(apiEndpoint,PROJECT1_ID).
+                	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
 	    			content(configureSecHub().
 	    					api("1.0").
@@ -219,6 +224,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
 	    	                    responseSchema(OpenApiSchema.JOB_ID.getSchema()).
 	    	                and().
 	    	                document(
+		    	                		requestHeaders(
+		    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+		    	                		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The unique id of the project id where a new sechub job shall be created")
                                         ),
@@ -260,6 +268,7 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
 	    this.mockMvc.perform(
 	    		post(apiEndpoint,PROJECT1_ID).
+                	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
 	    			content(configureSecHub().
 	    					api("1.0").
@@ -281,6 +290,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                                 responseSchema(OpenApiSchema.JOB_ID.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The unique id of the project id where a new sechub job shall be created")
                                         ),
@@ -317,6 +329,7 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
 	    this.mockMvc.perform(
 	    		post(apiEndpoint, PROJECT1_ID).
+                	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
 	    			content(configureSecHub().
 	    					api("1.0").
@@ -336,6 +349,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                                 responseSchema(OpenApiSchema.JOB_ID.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The unique id of the project id where a new sechub job shall be created")
                                         ),
@@ -373,6 +389,7 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
 	    this.mockMvc.perform(
 	    		post(apiEndpoint,PROJECT1_ID).
+	    			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue()).
 	    			contentType(MediaType.APPLICATION_JSON_VALUE).
 	    			content(configureSecHub().
 	    					api("1.0").
@@ -424,6 +441,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                             responseSchema(OpenApiSchema.JOB_ID.getSchema()).
                         and().
                         document(
+		                        		requestHeaders(
+		                        				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+		                        		),
                                         pathParameters(
                                                 parameterWithName(PROJECT_ID.paramName()).description("The unique id of the project id where a new sechub job shall be created")
                                         ),
@@ -476,7 +496,8 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
         this.mockMvc.perform(
         		multipart(apiEndpoint, PROJECT1_ID, randomUUID).
-        			file(file1).param("checkSum", "mychecksum")
+        			file(file1).param("checkSum", "mychecksum").
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isOk()).
         					// https://docs.spring.io/spring-restdocs/docs/2.0.2.RELEASE/reference/html5/
@@ -486,6 +507,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
+                            		requestHeaders(
+                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                            		),
                                     pathParameters(
                                             parameterWithName("projectId").description("The id of the project where sourcecode shall be uploaded for"),
                                             parameterWithName("jobUUID").description(DESCRIPTION_JOB_UUID)
@@ -532,7 +556,8 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                 multipart(apiEndpoint, PROJECT1_ID, randomUUID).
                     file(file1).
                     param("checkSum", "mychecksum").
-                    header(CommonConstants.FILE_SIZE_HEADER_FIELD_NAME, file1.getBytes().length)
+                    header(CommonConstants.FILE_SIZE_HEADER_FIELD_NAME, file1.getBytes().length).
+                    header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 ).
                     andExpect(status().isOk()).
                             // https://docs.spring.io/spring-restdocs/docs/2.0.2.RELEASE/reference/html5/
@@ -542,6 +567,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
+                            		requestHeaders(
+                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                            		),
                                     pathParameters(
                                             parameterWithName("projectId").description("The id of the project for which the binaries are uploaded for"),
                                             parameterWithName("jobUUID").description(DESCRIPTION_JOB_UUID)
@@ -586,7 +614,8 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
 	    this.mockMvc.perform(
 	    		put(apiEndpoint, PROJECT1_ID,randomUUID).
-	    			contentType(MediaType.APPLICATION_JSON_VALUE)
+	    			contentType(MediaType.APPLICATION_JSON_VALUE).
+	    			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 	    		).
 	    			andExpect(status().isOk()).
 	    			andDo(defineRestService().
@@ -595,10 +624,13 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
-	                                        pathParameters(
-	                                                    parameterWithName("projectId").description("The id of the project where sechub job shall be approved"),
-	                                                    parameterWithName("jobUUID").description(DESCRIPTION_JOB_UUID)
-	                                        )
+                            		requestHeaders(
+                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                            		),
+	                                pathParameters(
+	                                         parameterWithName("projectId").description("The id of the project where sechub job shall be approved"),
+	                                         parameterWithName("jobUUID").description(DESCRIPTION_JOB_UUID)
+	                                )
 	    				));
 
 	    /* @formatter:on */
@@ -630,7 +662,8 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
         /* execute + test @formatter:off */
         this.mockMvc.perform(
         		get(apiEndpoint, PROJECT1_ID,randomUUID).
-        			contentType(MediaType.APPLICATION_JSON_VALUE)
+        			contentType(MediaType.APPLICATION_JSON_VALUE).
+        			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isOk()).
         			andExpect(content().json("{jobUUID:"+randomUUID.toString()+", result:OK, state:ENDED, trafficLight:GREEN}")).
@@ -641,6 +674,9 @@ public class SchedulerRestControllerRestDocTest implements TestIsNecessaryForDoc
                                 responseSchema(OpenApiSchema.JOB_STATUS.getSchema()).
                             and().
                             document(
+	                            		 requestHeaders(
+	                            			headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		 ),
                                           pathParameters(
                                             parameterWithName("projectId").description("The id of the project where sechub job was started for"),
                                             parameterWithName("jobUUID").description(DESCRIPTION_JOB_UUID)

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ServerInfoAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/ServerInfoAdministrationRestControllerRestDocTest.java
@@ -4,6 +4,8 @@ package com.mercedesbenz.sechub.restdoc;
 import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -67,7 +69,8 @@ public class ServerInfoAdministrationRestControllerRestDocTest implements TestIs
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
 				get(apiEndpoint).
-					contentType(MediaType.TEXT_PLAIN_VALUE)
+					contentType(MediaType.TEXT_PLAIN_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 					andExpect(status().isOk()).
 					andExpect(content().string(SERVER_VERSION)).
@@ -77,7 +80,11 @@ public class ServerInfoAdministrationRestControllerRestDocTest implements TestIs
 		                            tag(RestDocFactory.extractTag(apiEndpoint)).
 		                            responseSchema(OpenApiSchema.SERVER_VERSION.getSchema()).
 		                        and().
-		                        document()
+		                        document(
+			    	                		requestHeaders(
+			    	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+			    	                		)
+		                        )
 					);
 		/* @formatter:on */
     }

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/SignupAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/SignupAdministrationRestControllerRestDocTest.java
@@ -5,6 +5,8 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -92,7 +94,8 @@ public class SignupAdministrationRestControllerRestDocTest implements TestIsNece
 
         /* execute + test @formatter:off */
         this.mockMvc.perform(
-        		get(apiEndpoint)
+        		get(apiEndpoint).
+        			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isOk()).
         			andExpect(content().json("[{\"userId\":\"johnsmith\",\"emailAdress\":\"john.smith@example.com\"},{\"userId\":\"janesmith\",\"emailAdress\":\"jane.smith@example.com\"}]")).
@@ -103,11 +106,14 @@ public class SignupAdministrationRestControllerRestDocTest implements TestIsNece
                                 responseSchema(OpenApiSchema.SIGNUP_LIST.getSchema()).
                             and().
             			    document(
-        	                    responseFields(
-        	                            fieldWithPath("[]").description("List of user signups").optional(),
-        	                            fieldWithPath("[]."+RestDocPathParameter.USER_ID.paramName()).type(JsonFieldType.STRING).description("The user id"),
-        	                            fieldWithPath("[].emailAdress").type(JsonFieldType.STRING).description("The email address")
-        	                    )
+        	                		requestHeaders(
+        	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+        	                		),
+	        	                    responseFields(
+	        	                            fieldWithPath("[]").description("List of user signups").optional(),
+	        	                            fieldWithPath("[]."+RestDocPathParameter.USER_ID.paramName()).type(JsonFieldType.STRING).description("The user id"),
+	        	                            fieldWithPath("[].emailAdress").type(JsonFieldType.STRING).description("The email address")
+	        	                    )
         	            )
         		);
 
@@ -123,7 +129,8 @@ public class SignupAdministrationRestControllerRestDocTest implements TestIsNece
 
         /* execute + test @formatter:off */
         this.mockMvc.perform(
-        		delete(apiEndpoint,"userId1")
+        		delete(apiEndpoint,"userId1").
+        			header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isOk()).
         			andDo(defineRestService().

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/StatusAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/StatusAdministrationRestControllerRestDocTest.java
@@ -5,6 +5,8 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -91,7 +93,8 @@ public class StatusAdministrationRestControllerRestDocTest implements TestIsNece
 
 		this.mockMvc.perform(
 				get(apiEndpoint, MappingIdentifier.CHECKMARX_NEWPROJECT_TEAM_ID.getId()).
-				contentType(MediaType.APPLICATION_JSON_VALUE)
+					contentType(MediaType.APPLICATION_JSON_VALUE).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				)./*
 				*/
 		andDo(print()).
@@ -103,6 +106,9 @@ public class StatusAdministrationRestControllerRestDocTest implements TestIsNece
                     responseSchema(OpenApiSchema.MAPPING_CONFIGURATION.getSchema()).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(MAPPING_ID.paramName()).description("The mapping Id")
                             ),
@@ -126,8 +132,9 @@ public class StatusAdministrationRestControllerRestDocTest implements TestIsNece
         /* execute + test @formatter:off */
         this.mockMvc.perform(
                 put(apiEndpoint, MappingIdentifier.CHECKMARX_NEWPROJECT_TEAM_ID.getId()).
-                contentType(MediaType.APPLICATION_JSON_VALUE).
-                content(mappingDataTeam.toJSON())
+	                contentType(MediaType.APPLICATION_JSON_VALUE).
+	                content(mappingDataTeam.toJSON()).
+	                header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
                 )./*
                 */
         andDo(print()).
@@ -139,6 +146,9 @@ public class StatusAdministrationRestControllerRestDocTest implements TestIsNece
                     requestSchema(OpenApiSchema.MAPPING_CONFIGURATION.getSchema()).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(MAPPING_ID.paramName()).description("The mappingID, identifiying which mapping shall be updated")
                             ),

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/UserAdministrationRestControllerRestDocTest.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/UserAdministrationRestControllerRestDocTest.java
@@ -5,6 +5,7 @@ import static com.mercedesbenz.sechub.restdoc.RestDocumentation.*;
 import static com.mercedesbenz.sechub.test.RestDocPathParameter.*;
 import static com.mercedesbenz.sechub.test.SecHubTestURLBuilder.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -111,8 +112,9 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
         this.mockMvc.perform(
-                put(apiEndpoint, USER_ID, EMAIL_ADDRESS)
-                )./*andDo(print()).*/
+                  put(apiEndpoint, USER_ID, EMAIL_ADDRESS).
+                  	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+                ).
         andExpect(status().isOk()).
         andDo(defineRestService().
                 with().
@@ -120,6 +122,9 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(USER_ID.paramName()).description("The userId of the user whose email adress will be changed"),
                                     parameterWithName(EMAIL_ADDRESS.paramName()).description("The new email address")
@@ -139,8 +144,9 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				post(apiEndpoint, RestDocPathParameter.USER_ID)
-				)./*andDo(print()).*/
+				  post(apiEndpoint, RestDocPathParameter.USER_ID).
+				  	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
                 with().
@@ -148,11 +154,13 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
-                            pathParameters(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
+                         	pathParameters(
                                     parameterWithName(USER_ID.paramName()).description("The userId of the user who becomes admin")
-                        )
+                            )
 				));
-
 		/* @formatter:on */
     }
 
@@ -165,7 +173,8 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				post(apiEndpoint,RestDocPathParameter.USER_ID)
+				  post(apiEndpoint,RestDocPathParameter.USER_ID).
+				  	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -174,9 +183,12 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             pathParameters(
                                     parameterWithName(USER_ID.paramName()).description("The userId of the user who becomes admin")
-                        )
+                            )
 				));
 
 		/* @formatter:on */
@@ -191,7 +203,8 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				delete(apiEndpoint, RestDocPathParameter.USER_ID)
+					delete(apiEndpoint, RestDocPathParameter.USER_ID).
+					header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -200,8 +213,11 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                     tag(RestDocFactory.extractTag(apiEndpoint)).
                 and().
                 document(
-                            pathParameters(
-                                    parameterWithName(USER_ID.paramName()).description("The userId of the user who shall be deleted")
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
+                        pathParameters(
+                                parameterWithName(USER_ID.paramName()).description("The userId of the user who shall be deleted")
                         )
 				));
 
@@ -217,7 +233,8 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
         this.mockMvc.perform(
-        		post(apiEndpoint, "user1")
+        		  post(apiEndpoint, "user1").
+        		  header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isCreated()).
         			andDo(defineRestService().
@@ -226,10 +243,13 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                                 tag(RestDocFactory.extractTag(apiEndpoint)).
                             and().
                             document(
-        	                            pathParameters(
-        	                                    parameterWithName(USER_ID.paramName()).description("The userId of the signup which shall be accepted")
-        	                )
-        		));
+                            		requestHeaders(
+                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                            		),
+        	                        pathParameters(
+        	                                 parameterWithName(USER_ID.paramName()).description("The userId of the signup which shall be accepted")
+        	                        )
+                    ));
 
 		/* @formatter:on */
     }
@@ -250,7 +270,8 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				get(apiEndpoint)
+				  get(apiEndpoint).
+				  header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
 				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
@@ -260,6 +281,9 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                     responseSchema(OpenApiSchema.USER_LIST.getSchema()).
                 and().
                 document(
+                		requestHeaders(
+                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+                		),
                             responseFields(
                                     fieldWithPath("[]").description("List of user Ids").optional()
                         )
@@ -283,8 +307,9 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
 		this.mockMvc.perform(
-				get(apiEndpoint)
-				)./*andDo(print()).*/
+				  get(apiEndpoint).
+				  header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
+				).
 		andExpect(status().isOk()).
 		andDo(defineRestService().
                 with().
@@ -293,6 +318,9 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                     responseSchema(OpenApiSchema.USER_LIST.getSchema()).
                 and().
                 document(
+	                		requestHeaders(
+	                				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                		),
                             responseFields(
                                     fieldWithPath("[]").description("List of admin Ids").optional()
                         )
@@ -323,7 +351,8 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
 
         /* execute + test @formatter:off */
         this.mockMvc.perform(
-        		get(apiEndpoint, "user1")
+        			get(apiEndpoint, "user1").
+  				  	header(AuthenticationHelper.HEADER_NAME, AuthenticationHelper.getHeaderValue())
         		).
         			andExpect(status().isOk()).
         			andDo(defineRestService().
@@ -333,6 +362,9 @@ public class UserAdministrationRestControllerRestDocTest implements TestIsNecess
                                 responseSchema(OpenApiSchema.USER_DETAILS.getSchema()).
                             and().
                             document(
+	                            		requestHeaders(
+	                            				headerWithName(AuthenticationHelper.HEADER_NAME).description(AuthenticationHelper.HEADER_DESCRIPTION)
+	                            		),
         	                            pathParameters(
         	                                    parameterWithName(USER_ID.paramName()).description("The user id of user to show details for")
         	                            ),


### PR DESCRIPTION
- created AuthenticationHelper
- used AuthenticationHelper in RestDoc Tests

NOTE: Reviewer:

- please check if the authentication headers are set for all RestDoc tests which require authentication
- for all RestDoc tests the formatter is off, therefore the formatting needs to be done manually. Please don't spend too much time on critizing that.

closes: #1581