### PR TITLE
Upgrade build to use Java 11 #1624

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -71,16 +71,16 @@ jobs:
       # ----------------------
       # Setup + Caching
       # ----------------------
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
-          distribution: adopt
+          java-version: 11
+          distribution: temurin
           cache: gradle
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.1
+          go-version: 1.19.1
       - uses: actions/cache@v3.0.8
         id: go-cache
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,16 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
-          distribution: adopt
+          java-version: 11
+          distribution: temurin
           cache: gradle
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.1
+          go-version: 1.19.1
       - uses: actions/cache@v3.0.8
         with:
           path: |

--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -27,11 +27,11 @@ jobs:
         run: git tag v${{ github.event.inputs.libraries-version }}-libraries
 
       # Build
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
-          distribution: adopt
+          java-version: 11
+          distribution: temurin
           cache: gradle
 
       - name: Build

--- a/gradle/build-java.gradle
+++ b/gradle/build-java.gradle
@@ -33,8 +33,8 @@ subprojects{
 	/* Setup UTF-8 for compile AND test compilation*/
 	[ compileJava, compileTestJava ]*.options*.encoding = 'UTF-8'
 
-	sourceCompatibility = '1.8'
-	targetCompatibility = '1.8'
+	sourceCompatibility = '11'
+	targetCompatibility = '11'
 
 
     def wireMockHttpPortValue = 8180;

--- a/sechub-api-java/build.gradle
+++ b/sechub-api-java/build.gradle
@@ -66,7 +66,6 @@ task callOpenAPIJavaGenerator(type: org.openapitools.generator.gradle.plugin.tas
     		version                     : "${project.version}",
             performBeanValidation		: "false",
             useBeanValidation    		: "false",
-            java8                		: "true",
             dateLibrary          		: "java8",
             serializableModel    		: "true",
             serializationLibrary 		: "jackson",
@@ -74,7 +73,7 @@ task callOpenAPIJavaGenerator(type: org.openapitools.generator.gradle.plugin.tas
             artifactDescription			: "The SecHub API library for Java",
             artifactUrl					: "https://github.com/mercedes-benz/sechub",
             legacyDiscriminatorBehavior : "false",
-            library 					: "jersey2",
+            library 					: "native", // Uses the Java HTTP Client (available in Java 11+)
             licenseName 				: "MIT",
             licenseUrl					: "https://github.com/mercedes-benz/sechub/blob/develop/LICENSE",
             developerEmail				: "",


### PR DESCRIPTION
- upgrade all GitHub Action workflows to use Java 11 and Eclipse Temurin #1624
- upgrade Go to 1.19.1 #1563
- use Java 11 and Java HTTP Client for OpenAPI Java API client generation

closes: #1624
closes: #1563
closes: #784