### PR TITLE
Bash interpreted part of the string as a variable

### DIFF
--- a/sechub-solution/env-initial-sechub
+++ b/sechub-solution/env-initial-sechub
@@ -2,7 +2,7 @@
 # Possible values are: localserver, debug
 SECHUB_START_MODE="localserver"
 ADMIN_USERID="admin"
-ADMIN_APITOKEN="myTop$ecret!"
+ADMIN_APITOKEN='myTop$ecret!'
 
 # Enable Java Debugging
 JAVA_ENABLE_DEBUG=false


### PR DESCRIPTION
Issue #1667
* Changed the double quotes to single (now bash doesn't interpret special symbols)

closes #1667 