### PR TITLE
Set CSP header for SecHub server and PDS

### DIFF
--- a/sechub-pds/src/main/java/com/mercedesbenz/sechub/pds/security/AbstractAllowPDSAPISecurityConfiguration.java
+++ b/sechub-pds/src/main/java/com/mercedesbenz/sechub/pds/security/AbstractAllowPDSAPISecurityConfiguration.java
@@ -52,7 +52,10 @@ public abstract class AbstractAllowPDSAPISecurityConfiguration extends WebSecuri
 			and().
 		csrf().
 			disable(). /* disable CSRF for api so we have no CSRF-TOKEN problems - POST would not work*/
-			httpBasic();/* no login screen, just basic auth */
+			httpBasic()./* no login screen, just basic auth */
+ 		and().
+			headers().
+				contentSecurityPolicy("default-src 'none'");
 
  		/* @formatter:on */
     }

--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/configuration/AbstractAllowSecHubAPISecurityConfiguration.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/configuration/AbstractAllowSecHubAPISecurityConfiguration.java
@@ -64,7 +64,10 @@ public abstract class AbstractAllowSecHubAPISecurityConfiguration extends WebSec
 			and().
 		csrf().
 			disable(). /* disable CSRF for api so we have no CSRF-TOKEN problems - POST would not work*/
-			httpBasic();/* no login screen, just basic auth */
+			httpBasic()./* no login screen, just basic auth */
+		and().
+			headers().
+				contentSecurityPolicy("default-src 'none'");
 
  		/* @formatter:on */
     }


### PR DESCRIPTION
Successfully tested local scan with sechub and pds-gosec. Also verified that the header is set as expected on the sechub server and the PDS.

Alternatively we could set `default-src 'self'` instead of `default-src 'none'`.

- closes #1672 