### PR TITLE
Upgrade Scancode and dependencies #1863

### DIFF
--- a/sechub-pds-solutions/pds-base/docker/run.sh
+++ b/sechub-pds-solutions/pds-base/docker/run.sh
@@ -52,8 +52,10 @@ start_server() {
     echo "---"
     /run_additional.sh
     echo "---"
-
+    echo ""
     echo "Starting the SecHub PDS server"
+    echo "PDS Version: $PDS_VERSION"
+
     # Regarding entropy collection:
     #   with JDK 8+ the "obscure workaround using file:///dev/urandom 
     #   and file:/dev/./urandom is no longer required."

--- a/sechub-pds-solutions/pds-base/env
+++ b/sechub-pds-solutions/pds-base/env
@@ -10,7 +10,7 @@ CPU_LIMIT=1.0
 BUILD_TYPE=download
 
 # The PDS version used if the BUILD_TYPE is set to `download` 
-PDS_VERSION="0.33.0"
+PDS_VERSION="0.34.1"
 
 # Go version used
 GO="go1.19.linux-amd64.tar.gz"

--- a/sechub-pds-solutions/scancode/01-start-single-docker-compose.sh
+++ b/sechub-pds-solutions/scancode/01-start-single-docker-compose.sh
@@ -9,7 +9,7 @@ ENVIRONMENT_FILE=".env-single"
 
 # Only variables from .env can be used in the Docker-Compose file
 # all other variables are only available in the container
-setup_environment_file ".env" "env"
+setup_environment_file ".env" "env" "$ENVIRONMENT_FILES_FOLDER/env-base-image"
 setup_environment_file "$ENVIRONMENT_FILE" "$ENVIRONMENT_FILES_FOLDER/env-base"
 
 # Use Docker BuildKit

--- a/sechub-pds-solutions/scancode/05-start-single-sechub-network-docker-compose.sh
+++ b/sechub-pds-solutions/scancode/05-start-single-sechub-network-docker-compose.sh
@@ -9,7 +9,7 @@ ENVIRONMENT_FILE=".env-single"
 
 # Only variables from .env can be used in the Docker-Compose file
 # all other variables are only available in the container
-setup_environment_file ".env" "env"
+setup_environment_file ".env" "env" "$ENVIRONMENT_FILES_FOLDER/env-base-image"
 setup_environment_file "$ENVIRONMENT_FILE" "$ENVIRONMENT_FILES_FOLDER/env-base"
 
 # Use Docker BuildKit

--- a/sechub-pds-solutions/scancode/50-start-multiple-docker-compose.sh
+++ b/sechub-pds-solutions/scancode/50-start-multiple-docker-compose.sh
@@ -9,7 +9,7 @@ ENVIRONMENT_FILE=".env-cluster"
 
 # Only variables from .env can be used in the Docker-Compose file
 # all other variables are only available in the container
-setup_environment_file ".env" "env"
+setup_environment_file ".env" "env" "$ENVIRONMENT_FILES_FOLDER/env-base-image"
 setup_environment_file "$ENVIRONMENT_FILE" "$ENVIRONMENT_FILES_FOLDER/env-base" "$ENVIRONMENT_FILES_FOLDER/env-cluster" "env-database"
 
 if [[ -z "$REPLICAS" ]]

--- a/sechub-pds-solutions/scancode/51-start-multiple-object-storage-docker-compose.sh
+++ b/sechub-pds-solutions/scancode/51-start-multiple-object-storage-docker-compose.sh
@@ -9,7 +9,7 @@ ENVIRONMENT_FILE=".env-cluster-object-storage"
 
 # Only variables from .env can be used in the Docker-Compose file
 # all other variables are only available in the container
-setup_environment_file ".env" "env"
+setup_environment_file ".env" "env" "$ENVIRONMENT_FILES_FOLDER/env-base-image"
 setup_environment_file "$ENVIRONMENT_FILE" "$ENVIRONMENT_FILES_FOLDER/env-base" "$ENVIRONMENT_FILES_FOLDER/env-cluster" "$ENVIRONMENT_FILES_FOLDER/env-object-storage" "env-database"
 
 

--- a/sechub-pds-solutions/scancode/docker-compose_pds_scancode.yaml
+++ b/sechub-pds-solutions/scancode/docker-compose_pds_scancode.yaml
@@ -6,6 +6,7 @@ services:
         build:
             args:
                 - BASE_IMAGE=${BASE_IMAGE}
+                - SCANCODE_VERSION=${SCANCODE_VERSION}
             context: docker/
             dockerfile: Scancode-Debian.dockerfile
         container_name: pds-scancode

--- a/sechub-pds-solutions/scancode/docker-compose_pds_scancode_cluster.yaml
+++ b/sechub-pds-solutions/scancode/docker-compose_pds_scancode_cluster.yaml
@@ -6,6 +6,7 @@ services:
         build:
             args:
                 - BASE_IMAGE=${BASE_IMAGE}
+                - SCANCODE_VERSION=${SCANCODE_VERSION}
             context: docker/
             dockerfile: Scancode-Debian.dockerfile
         env_file:

--- a/sechub-pds-solutions/scancode/docker-compose_pds_scancode_cluster_object_storage.yaml
+++ b/sechub-pds-solutions/scancode/docker-compose_pds_scancode_cluster_object_storage.yaml
@@ -6,6 +6,7 @@ services:
         build:
             args:
                 - BASE_IMAGE=${BASE_IMAGE}
+                - SCANCODE_VERSION=${SCANCODE_VERSION}
             context: docker/
             dockerfile: Scancode-Debian.dockerfile
         env_file:

--- a/sechub-pds-solutions/scancode/docker-compose_pds_scancode_external-network.yaml
+++ b/sechub-pds-solutions/scancode/docker-compose_pds_scancode_external-network.yaml
@@ -6,6 +6,7 @@ services:
         build:
             args:
                 - BASE_IMAGE=${BASE_IMAGE}
+                - SCANCODE_VERSION=${SCANCODE_VERSION}
             context: docker/
             dockerfile: Scancode-Debian.dockerfile
         container_name: pds-scancode

--- a/sechub-pds-solutions/scancode/docker/Scancode-Debian.dockerfile
+++ b/sechub-pds-solutions/scancode/docker/Scancode-Debian.dockerfile
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.description="A container which combines Scancode-
 LABEL maintainer="SecHub FOSS Team"
 
 # Build args
-ARG SCANCODE_VERSION="31.2.1"
-ARG SPDX_TOOL_VERISON="1.1.2"
-ARG SPDX_TOOL_CHECKSUM="4a2f1a2f3a12b96fc13675e78871a33dc12f6e44c7dbdcda2e5ea92f994615e8  tools-java-1.1.2-jar-with-dependencies.jar"
+ARG SCANCODE_VERSION
+ARG SPDX_TOOL_VERISON="1.1.3"
+ARG SPDX_TOOL_CHECKSUM="766a1ddc23e70644c115e0e68d487c5ab586a58a67a7889c7e181ace23a45abe  tools-java-1.1.3-jar-with-dependencies.jar"
 
 # Environment variables in container
 ENV SCANCODE_VERSION="${SCANCODE_VERSION}"

--- a/sechub-pds-solutions/scancode/env
+++ b/sechub-pds-solutions/scancode/env
@@ -1,5 +1,2 @@
-# The base image to use
-# uncomment to use local image
-# BASE_IMAGE="pds-base_pds"
-BASE_IMAGE="ghcr.io/mercedes-benz/sechub/pds-base:v0.33.0"
 PDS_UPLOAD_MAXIMUM_BYTES=26214400000
+SCANCODE_VERSION="31.2.4"

--- a/sechub-pds-solutions/scancode/env-database
+++ b/sechub-pds-solutions/scancode/env-database
@@ -4,6 +4,6 @@
 DATABASE_START_MODE=server
 POSTGRES_ENABLED=true
 DATABASE_CONNECTION=jdbc:postgresql://database:5432/pds?currentSchema=scancode
-DATABASE_PASSWORD=top$ecret
+DATABASE_PASSWORD='top$ecret'
 DATABASE_USERNAME=scancode
 

--- a/sechub-pds-solutions/shared/environment/env-base-image
+++ b/sechub-pds-solutions/shared/environment/env-base-image
@@ -1,0 +1,4 @@
+# The base image to use
+# uncomment to use local image
+# BASE_IMAGE="pds-base_pds"
+BASE_IMAGE="ghcr.io/mercedes-benz/sechub/pds-base:v0.34.1"

--- a/sechub-pds-solutions/shared/scripts/9999-helper.sh
+++ b/sechub-pds-solutions/shared/scripts/9999-helper.sh
@@ -12,7 +12,7 @@ function setup_environment_file() {
         
         # take arguments from the 2nd to the nth element
         # combine all the files into the settings file
-        cat $@ > "$environment_file"
+        cat "$@" > "$environment_file"
     else
         echo "Using existing environment file: $environment_file."
     fi

--- a/sechub-pds-solutions/shared/scripts/9999-helper.sh
+++ b/sechub-pds-solutions/shared/scripts/9999-helper.sh
@@ -12,7 +12,7 @@ function setup_environment_file() {
         
         # take arguments from the 2nd to the nth element
         # combine all the files into the settings file
-        cat $* > "$environment_file"
+        cat $@ > "$environment_file"
     else
         echo "Using existing environment file: $environment_file."
     fi


### PR DESCRIPTION
- upgrade scancode
- upgrade SPDX Tools
- enable changing the scancode version locally
- introduce env-base-image to centralize the base image version
- use env-base-image for scancode
- add PDS_VERSION to PDS output

closes: #1863