### PR TITLE
Rename OpenAPI schema

### DIFF
--- a/sechub-doc/build.gradle
+++ b/sechub-doc/build.gradle
@@ -353,7 +353,7 @@ task generateOpenapi() {
     	def listOfUsersSchema = jsonObject.components.schemas.ListOfUsers
     	listOfUsersSchema.items = stringType
 
-    	def projectWhiteListSchema = jsonObject.components.schemas.ProjectWhitelist
+    	def projectWhiteListSchema = jsonObject.components.schemas.ProjectWhitelistUpdate
     	projectWhiteListSchema.properties.whiteList.properties.uris.items=stringType
     	
     	// Write JSON

--- a/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/OpenApiSchema.java
+++ b/sechub-doc/src/test/java/com/mercedesbenz/sechub/restdoc/OpenApiSchema.java
@@ -20,7 +20,7 @@ enum OpenApiSchema {
 
     MOCK_DATA_CONFIGURATION("MockDataConfiguration"),
 
-    PROJECT_WHITELIST("ProjectWhitelist"),
+    PROJECT_WHITELIST("ProjectWhitelistUpdate"),
 
     PROJECT("Project"), PROJECT_LIST("ListOfProjects"),
 


### PR DESCRIPTION
I figured out a way to avoid the name collision mentioned in https://github.com/mercedes-benz/sechub/issues/1866#issuecomment-1387253053. I believe this change shouldn't mess anything up, since the API stays the same?

closes #1866 