### PR TITLE
feature 1995 - cyclonDX sbom generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,8 @@ apply plugin: 'org.cyclonedx.bom'
 cyclonedxBom {
   includeConfigs = ["runtimeClasspath"]
 }
-// cyclonDx works only with group and version
-group = 'com.mercedesbenz.sechub'
-version = '0.0.0'
+
+version = VersionData.getServerVersion()
 
 
 /* check buildsystem */
@@ -100,6 +99,7 @@ tasks.clean.dependsOn.internalCleanRootBuildFolder
 apply from: rootProject.file('gradle/gradle_version_plugin.gradle')
 
 allprojects {
+    group = "com.mercedesbenz.sechub"
     apply from: rootProject.file('gradle/spotless.gradle')
 
     def customMavenRepoURL = System.getenv('CUST_MVN_URL')

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript{
 		classpath "org.ajoberstar.grgit:grgit-gradle:${libraryVersion.grgit}" // necessary for version calculation
 		classpath "com.epages:restdocs-api-spec-gradle-plugin:${libraryVersion.restDocsApiSpec}"
         classpath "org.owasp:dependency-check-gradle:${libraryVersion.dependency_check}"
+        classpath "org.cyclonedx:cyclonedx-gradle-plugin:1.7.4"
 	}
 }
 
@@ -49,6 +50,17 @@ plugins {
 
 // old style apply necessary here - to have same version as in classpath dependency
 apply plugin: 'org.owasp.dependencycheck'
+
+// applying cyclonDX plugin
+apply plugin: 'org.cyclonedx.bom'
+// generate sbom only with runtime dependencies
+cyclonedxBom {
+  includeConfigs = ["runtimeClasspath"]
+}
+// cyclonDx works only with group and version
+group = 'com.mercedesbenz.sechub'
+version = '0.0.0'
+
 
 /* check buildsystem */
 def githubActor = System.getenv('GITHUB_ACTOR')

--- a/gradle/build-maven.gradle
+++ b/gradle/build-maven.gradle
@@ -10,7 +10,6 @@
 
 subprojects {
 
-	group = "com.mercedesbenz.sechub"
 
     if (!projectType.publishedLibraries.contains(project)){
         return;


### PR DESCRIPTION
Added CyclonDx Gradle plugin for automated SBOM generation. SBOM includes only runtime dependencies.
Usage: `./gradlew cyclonedxBom`

closes: #1995 