### PR TITLE
Fix problem of missing code call hierarchy in reports for scan type `secretScan`

### DIFF
--- a/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertReport.java
+++ b/sechub-integrationtest/src/main/java/com/mercedesbenz/sechub/integrationtest/api/AssertReport.java
@@ -207,6 +207,14 @@ public class AssertReport {
             return this;
         }
 
+        public AssertFinding hasNoCweId() {
+            if (finding.getCweId() != null) {
+                dump();
+                autoDumper.execute(() -> fail("CWE id found inside finding:" + finding.getCweId()));
+            }
+            return this;
+        }
+
         public AssertCodeCall codeCall(int level) {
             int currentLevel = 0;
             SecHubCodeCallStack code = finding.getCode();

--- a/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario20/PDSSecretScanJobScenario20IntTest.java
+++ b/sechub-integrationtest/src/test/java/com/mercedesbenz/sechub/integrationtest/scenario20/PDSSecretScanJobScenario20IntTest.java
@@ -21,6 +21,7 @@ import com.mercedesbenz.sechub.integrationtest.api.TestProject;
 import com.mercedesbenz.sechub.integrationtest.internal.IntegrationTestFileSupport;
 
 public class PDSSecretScanJobScenario20IntTest {
+
     public static final String PATH = "pds/secretscan/upload/zipfile_contains_inttest_secretscan_with_gitleaks_sample_sarif.json.zip";
 
     @Rule
@@ -53,8 +54,15 @@ public class PDSSecretScanJobScenario20IntTest {
         hasTrafficLight(GREEN).
         hasFindings(6).
 	        finding(0).
-	        hasScanType(ScanType.SECRET_SCAN).
-	        hasDescription("generic-api-key has detected secret for file UnSAFE_Bank/Backend/docker-compose.yml.");
+	          hasScanType(ScanType.SECRET_SCAN).
+	          hasDescription("generic-api-key has detected secret for file UnSAFE_Bank/Backend/docker-compose.yml.").
+	          codeCall(0).
+	              hasColumn(14).
+	              hasLine(12).
+	              hasSource("531486b2bf646636a6a1bba61e78ec4a4a54efbd").
+	              hasLocation("UnSAFE_Bank/Backend/docker-compose.yml").
+	          andFinding().
+	          hasNoCweId();// the results are from gitleaks product, which does not include CWE information
         /* @formatter:on */
     }
 }

--- a/sechub-scan-product-sereco/src/main/java/com/mercedesbenz/sechub/domain/scan/product/sereco/SerecoProductResultTransformer.java
+++ b/sechub-scan-product-sereco/src/main/java/com/mercedesbenz/sechub/domain/scan/product/sereco/SerecoProductResultTransformer.java
@@ -109,6 +109,7 @@ public class SerecoProductResultTransformer implements ReportProductResultTransf
             }
             switch (scanType) {
             case CODE_SCAN:
+            case SECRET_SCAN:
                 finding.setCode(convert(vulnerability.getCode()));
                 break;
             case INFRA_SCAN:

--- a/sechub-scan-product-sereco/src/test/java/com/mercedesbenz/sechub/domain/scan/product/sereco/SerecoProductResultTransformerTest.java
+++ b/sechub-scan-product-sereco/src/test/java/com/mercedesbenz/sechub/domain/scan/product/sereco/SerecoProductResultTransformerTest.java
@@ -51,6 +51,42 @@ public class SerecoProductResultTransformerTest {
     }
 
     @Test
+    public void one_vulnerability_as_secret_in_meta_results_in_one_finding() throws Exception {
+        /* prepare */
+        String converted = createMetaDataWithOneVulnerabilityAsSecretFound();
+
+        /* execute */
+        ReportTransformationResult result = transformerToTest.transform(createProductResult(converted));
+
+        /* test */
+        SecHubResult sechubResult = result.getResult();
+        for (SecHubFinding finding : sechubResult.getFindings()) {
+            assertEquals(ScanType.SECRET_SCAN, finding.getType());
+        }
+
+        AssertSecHubResult.assertSecHubResult(sechubResult).hasFindings(1);
+        SecHubFinding finding1 = sechubResult.getFindings().get(0);
+        assertEquals(Integer.valueOf(4711), finding1.getCweId());
+
+        SecHubCodeCallStack code1 = finding1.getCode();
+        assertNotNull(code1);
+        assertEquals(Integer.valueOf(1), code1.getLine());
+        assertEquals(Integer.valueOf(2), code1.getColumn());
+        assertEquals("Location1", code1.getLocation());
+        assertEquals("source1", code1.getSource());
+        assertEquals("relevantPart1", code1.getRelevantPart());
+
+        SecHubCodeCallStack code2 = code1.getCalls();
+        assertNotNull(code2);
+        assertEquals(Integer.valueOf(3), code2.getLine());
+        assertEquals(Integer.valueOf(4), code2.getColumn());
+        assertEquals("Location2", code2.getLocation());
+        assertEquals("source2", code2.getSource());
+        assertEquals("relevantPart2", code2.getRelevantPart());
+
+    }
+
+    @Test
     public void one_vulnerability_as_code_in_meta_results_in_one_finding() throws Exception {
         /* prepare */
         String converted = createMetaDataWithOneVulnerabilityAsCodeFound();
@@ -66,6 +102,7 @@ public class SerecoProductResultTransformerTest {
 
         AssertSecHubResult.assertSecHubResult(sechubResult).hasFindings(1);
         SecHubFinding finding1 = sechubResult.getFindings().get(0);
+        assertEquals(Integer.valueOf(4711), finding1.getCweId());
 
         SecHubCodeCallStack code1 = finding1.getCode();
         assertNotNull(code1);
@@ -195,13 +232,21 @@ public class SerecoProductResultTransformerTest {
     }
 
     private String createMetaDataWithOneVulnerabilityAsCodeFound() {
+        return createMetaDataWithOneVulnerability(ScanType.CODE_SCAN);
+    }
+
+    private String createMetaDataWithOneVulnerabilityAsSecretFound() {
+        return createMetaDataWithOneVulnerability(ScanType.SECRET_SCAN);
+    }
+
+    private String createMetaDataWithOneVulnerability(ScanType scanType) {
         SerecoMetaData data = new SerecoMetaData();
         List<SerecoVulnerability> vulnerabilities = data.getVulnerabilities();
 
         SerecoVulnerability v1 = new SerecoVulnerability();
         v1.setSeverity(SerecoSeverity.MEDIUM);
         v1.setType("type1");
-        v1.setScanType(ScanType.CODE_SCAN);
+        v1.setScanType(scanType);
 
         SerecoCodeCallStackElement serecoCode1 = new SerecoCodeCallStackElement();
         serecoCode1.setLine(1);
@@ -223,6 +268,7 @@ public class SerecoProductResultTransformerTest {
 
         SerecoClassification cl = v1.getClassification();
         cl.setCapec("capec1");
+        cl.setCwe("4711");
 
         vulnerabilities.add(v1);
 


### PR DESCRIPTION
This PR
- closes #2014