### PR TITLE
Feature 2059 additional executor profiles

### DIFF
--- a/sechub-solution/setup-pds/executors/checkmarx-and-gosec/README.md
+++ b/sechub-solution/setup-pds/executors/checkmarx-and-gosec/README.md
@@ -1,0 +1,3 @@
+# Info
+
+`checkmarx-filtered.json` and `gosec-filtered.json` are meant to be used together in a execution profile. Sourcecode of projects that are assigned to this profile will be split, Go-code will be scanned by gosec and the rest of the sourcecode will be scanned by checkmarx.

--- a/sechub-solution/setup-pds/executors/checkmarx-and-gosec/checkmarx-filtered.json
+++ b/sechub-solution/setup-pds/executors/checkmarx-and-gosec/checkmarx-filtered.json
@@ -15,6 +15,10 @@
                 "value": "PDS_CHECKMARX"
             },
             {
+                "key": "pds.config.filefilter.excludes",
+                "value": "*.go"
+            },
+            {
                 "key": "pds.config.use.sechub.storage",
                 "value": false
             },

--- a/sechub-solution/setup-pds/executors/checkmarx-and-gosec/checkmarx-filtered.json
+++ b/sechub-solution/setup-pds/executors/checkmarx-and-gosec/checkmarx-filtered.json
@@ -1,0 +1,71 @@
+{
+    "name": "pds-checkmarx",
+    "productIdentifier": "PDS_CODESCAN",
+    "executorVersion": 1,
+    "enabled": true,
+    "setup": {
+        "baseURL": "https://pds-checkmarx:8444",
+        "credentials": {
+            "user": "techuser",
+            "password": "pds-apitoken"
+        },
+        "jobParameters": [
+            {
+                "key": "pds.config.productidentifier",
+                "value": "PDS_CHECKMARX"
+            },
+            {
+                "key": "pds.config.use.sechub.storage",
+                "value": false
+            },
+            {
+                "key": "pds.mocking.disabled",
+                "value": false
+            },
+            {
+                "key": "pds.productexecutor.timeout.minutes",
+                "value": 600
+            },
+            {
+                "key": "pds.productexecutor.timetowait.nextcheck.milliseconds",
+                "value": 30000
+            },
+            {
+                "key": "pds.productexecutor.trustall.certificates",
+                "value": true
+            },
+            {
+                "key": "pds.checkmarx.baseurl",
+                "value": "https://checkmarx.example.org"
+            },
+            {
+                "key": "checkmarx.newproject.teamid.mapping",
+                "value": "{\"entries\":[{\"pattern\":\".*\",\"replacement\":\"42\",\"comment\":\"sechub-team-default\"}]}"
+            },
+            {
+                "key": "pds.checkmarx.user",
+                "value": "sechub"
+            },
+            {
+                "key": "pds.checkmarx.password",
+                "value": "$uper$ecret123!"
+            },
+            {
+                "key": "pds.checkmarx.always.fullscan.enabled",
+                "value": "true"
+            },
+            {
+                "key": "checkmarx.newproject.presetid.mapping",
+                "value": "{}"
+            },
+            {
+                "key": "pds.checkmarx.engine.configuration.name",
+                "value": "Multi Language"
+            },
+            {
+                "key": "pds.config.script.trustall.certificates.enabled",
+                "value": true
+            }
+        ]
+    }
+}

--- a/sechub-solution/setup-pds/executors/checkmarx-and-gosec/gosec-filtered.json
+++ b/sechub-solution/setup-pds/executors/checkmarx-and-gosec/gosec-filtered.json
@@ -1,0 +1,43 @@
+{
+    "name": "pds-gosec",
+    "productIdentifier": "PDS_CODESCAN",
+    "executorVersion": 1,
+    "enabled": true,
+    "setup": {
+        "baseURL": "https://pds-gosec:8444",
+        "credentials": {
+            "user": "techuser",
+            "password": "pds-apitoken"
+        },
+        "jobParameters": [
+            {
+                "key": "pds.config.productidentifier",
+                "value": "PDS_GOSEC"
+            },
+            {
+                "key": "pds.config.filefilter.includes",
+                "value": "*.go"
+            },
+            {
+                "key": "pds.config.use.sechub.storage",
+                "value": false
+            },
+            {
+                "key": "pds.mocking.disabled",
+                "value": true
+            },
+            {
+                "key": "pds.productexecutor.timeout.minutes",
+                "value": 60
+            },
+            {
+                "key": "pds.productexecutor.timetowait.nextcheck.milliseconds",
+                "value": 500
+            },
+            {
+                "key": "pds.productexecutor.trustall.certificates",
+                "value": true
+            }
+        ]
+    }
+}


### PR DESCRIPTION
I created a new folder and a README so it will hopefully be clear that the executor configs are meant to be used together. Both executor configs are exactly the same as those in the folder above, except for lines 17-20 in both json files.