### PR TITLE
add new action to build owasp zap wrapper into develop branch #1616

### DIFF
--- a/.github/workflows/create-pds-tools-release.yml
+++ b/.github/workflows/create-pds-tools-release.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-name: PDS-Tools-Release
+name: Release PDS-Tools
 
 on:
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
           java-version: 11
           distribution: temurin
           cache: gradle
-          
+
       # ----------------------
       # Create pull request if license headers are missing
       # ----------------------

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -149,7 +149,7 @@ jobs:
         run: ./gradlew :sechub-api-java:buildAPIJava
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      
+
       # ----------------------
       # Integration test
       # ----------------------
@@ -551,7 +551,7 @@ jobs:
           asset_path: sechub-pds/build/libs/sechub-pds-${{ github.event.inputs.pds-version }}.jar.sha256sum
           asset_name: sechub-pds-${{ github.event.inputs.pds-version }}.jar.sha256sum
           asset_content_type: text/plain
-          
+
       # sechub-pds-wrapperowaspzap
       - name: Create files and sha256 checksum for PDS OWASP ZAP wrapper
         if: github.event.inputs.pds-version != ''
@@ -578,7 +578,7 @@ jobs:
           asset_path: sechub-wrapper-owasp-zap/build/libs/sechub-pds-wrapperowaspzap-${{ github.event.inputs.pds-version }}.jar.sha256sum
           asset_name: sechub-pds-wrapperowaspzap-${{ github.event.inputs.pds-version }}.jar.sha256sum
           asset_content_type: text/plain
-      
+
       # sechub-wrapper-checkmarx
       - name: Create files and sha256 checksum for PDS Checkmarx wrapper
         if: github.event.inputs.pds-version != ''
@@ -605,7 +605,7 @@ jobs:
           asset_path: sechub-wrapper-checkmarx/build/libs/sechub-wrapper-checkmarx-${{ github.event.inputs.pds-version }}.jar.sha256sum
           asset_name: sechub-wrapper-checkmarx-${{ github.event.inputs.pds-version }}.jar.sha256sum
           asset_content_type: text/plain
-      
+
       # sechub-product-delegation-server.pdf
       - name: Upload PDS release asset sechub-product-delegation-server-${{ github.event.inputs.pds-version }}.pdf
         if: github.event.inputs.pds-version != ''

--- a/.github/workflows/release-owaspzap-wrapper.yml
+++ b/.github/workflows/release-owaspzap-wrapper.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+name: Release OWASP-ZAP wrapper
+
+on:
+  workflow_dispatch:
+    inputs:
+      owaspzap-wrapper-version:
+        description: OWASP-ZAP-wrapper Version (e.g. 1.0.0)
+        required: true
+      owaspzap-wrapper-milestone-number:
+        description: OWASP-ZAP-wrapper Milestone number (e.g. 90)
+        required: true
+jobs:
+  release-version:
+    name: Create OWASP-ZAP-wrapper release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Show Inputs"
+        run: |
+          echo "OWASP-ZAP-wrapper '${{ github.event.inputs.owaspzap-wrapper-version }}' - Milestone '${{ github.event.inputs.owaspzap-wrapper-milestone-number }}'"


### PR DESCRIPTION
- To enable testing the zap wrapper release job on github. Functionality comes with a separate PR.
- Consistent naming pattern (PDS-Tools)
- whitespace changes