### PR TITLE
Feature 2201 improve inital target connection check and make it configurable

### DIFF
--- a/sechub-pds-solutions/owasp-zap/docker/pds-config.json
+++ b/sechub-pds-solutions/owasp-zap/docker/pds-config.json
@@ -6,7 +6,7 @@
       "id": "PDS_OWASP_ZAP",
       "path": "/scripts/owasp-zap.sh",
       "scanType": "webScan",
-      "minutesToWaitForProductResult": 510,
+      "minutesToWaitForProductResult": 600,
       "description": "Runs OWASP ZAP",
       "parameters": {
         "mandatory": [
@@ -49,6 +49,10 @@
           	"description": "Comma separated list of rule references that will be deactivated during the scan."
           },
           {
+          	"key": "wrapper.connectioncheck.enabled",
+          	"description": "Enable/disable initial connection done by the Owasp Zap wrapper."
+          },
+          {
           	"key": "wrapper.maximum.connection.retries",
           	"description": "Maximum amount of retries the wrapper does for each URL to check if it is reachable."
           },
@@ -68,13 +72,13 @@
         "mandatory": [
           {
             "key": "pds.scan.target.url",
-            "description": "The target url for the scan"
+            "description": "The target url for the scan."
           }
         ],
         "optional": [
           {
             "key": "pds.scan.configuration",
-            "description": "The configuration of the web scan"
+            "description": "The configuration of the web scan."
           },
           {
             "key": "zap.activescan.enabled",
@@ -86,7 +90,7 @@
           },
           {
             "key": "zap.use.proxy",
-            "description": "Enable/disable proxy for scanning. This overwrites the target type configuration."
+            "description": "Enable/disable proxy for scanning."
           },
           {
             "key": "zap.proxy.host",
@@ -103,6 +107,18 @@
           {
           	"key": "zap.deactivated.rule.references",
           	"description": "Comma separated list of rule references that will be deactivated during the scan."
+          },
+          {
+          	"key": "wrapper.connectioncheck.enabled",
+          	"description": "Enable/disable initial connection done by the Owasp Zap wrapper."
+          },
+          {
+          	"key": "wrapper.maximum.connection.retries",
+          	"description": "Maximum amount of retries the wrapper does for each URL to check if it is reachable."
+          },
+          {
+          	"key": "wrapper.retry.waittime.milliseconds",
+          	"description": "The time to wait between connection checks to the same URL. The value cannot be less than 1000 milliseconds."
           }
         ]
       }

--- a/sechub-pds-solutions/owasp-zap/docker/pds-config.json
+++ b/sechub-pds-solutions/owasp-zap/docker/pds-config.json
@@ -45,20 +45,23 @@
             "description": "Use proxy for PDS target type: INTERNET or INTRANET."
           },
           {
-          	"key": "zap.deactivated.rule.references",
-          	"description": "Comma separated list of rule references that will be deactivated during the scan."
+            "key": "zap.deactivated.rule.references",
+            "description": "Comma separated list of rule references that will be deactivated during the scan."
           },
           {
-          	"key": "wrapper.connectioncheck.enabled",
-          	"description": "Enable/disable initial connection done by the Owasp Zap wrapper."
+            "key": "wrapper.connectioncheck.enabled",
+            "description": "Enable/disable initial connection done by the Owasp Zap wrapper.",
+            "default": false
           },
           {
-          	"key": "wrapper.maximum.connection.retries",
-          	"description": "Maximum amount of retries the wrapper does for each URL to check if it is reachable."
+            "key": "wrapper.maximum.connection.retries",
+            "description": "Maximum amount of retries the wrapper does for each URL to check if it is reachable.",
+            "default": 3
           },
           {
-          	"key": "wrapper.retry.waittime.milliseconds",
-          	"description": "The time to wait between connection checks to the same URL. The value cannot be less than 1000 milliseconds."
+            "key": "wrapper.retry.waittime.milliseconds",
+            "description": "The time to wait between connection checks to the same URL. The value cannot be less than 1000 milliseconds.",
+            "default": 1000
           }
         ]
       }
@@ -105,20 +108,23 @@
             "description": "Use proxy for PDS target type: INTERNET or INTRANET."
           },
           {
-          	"key": "zap.deactivated.rule.references",
-          	"description": "Comma separated list of rule references that will be deactivated during the scan."
+            "key": "zap.deactivated.rule.references",
+            "description": "Comma separated list of rule references that will be deactivated during the scan."
           },
           {
-          	"key": "wrapper.connectioncheck.enabled",
-          	"description": "Enable/disable initial connection done by the Owasp Zap wrapper."
+            "key": "wrapper.connectioncheck.enabled",
+            "description": "Enable/disable initial connection done by the Owasp Zap wrapper.",
+            "default": false
           },
           {
-          	"key": "wrapper.maximum.connection.retries",
-          	"description": "Maximum amount of retries the wrapper does for each URL to check if it is reachable."
+            "key": "wrapper.maximum.connection.retries",
+            "description": "Maximum amount of retries the wrapper does for each URL to check if it is reachable.",
+            "default": 3
           },
           {
-          	"key": "wrapper.retry.waittime.milliseconds",
-          	"description": "The time to wait between connection checks to the same URL. The value cannot be less than 1000 milliseconds."
+            "key": "wrapper.retry.waittime.milliseconds",
+            "description": "The time to wait between connection checks to the same URL. The value cannot be less than 1000 milliseconds.",
+            "default": 1000
           }
         ]
       }

--- a/sechub-pds-solutions/owasp-zap/docker/scripts/owasp-zap.sh
+++ b/sechub-pds-solutions/owasp-zap/docker/scripts/owasp-zap.sh
@@ -81,6 +81,14 @@ else
     echo "Use proxy: disabled"
 fi
 
+if [ "$WRAPPER_CONNECTIONCHECK_ENABLED" = "true" ]
+then
+    echo "Wrapper connection check: enabled"
+    options="$options --connectionCheck"
+else
+    echo "Wrapper connection check: disabled"
+fi
+
 if [ ! -z "$WRAPPER_MAXIMUM_CONNECTION_RETRIES" ]
 then
     echo "Use WRAPPER_MAXIMUM_CONNECTION_RETRIES: $WRAPPER_MAXIMUM_CONNECTION_RETRIES"

--- a/sechub-wrapper-owasp-zap/README.adoc
+++ b/sechub-wrapper-owasp-zap/README.adoc
@@ -32,6 +32,10 @@ Usage: OwaspZapWrapper [options]
     --ajaxSpider
       Set this option to enable Owasp Zap ajaxSpider.
       Default: false
+    --connectionCheck
+      Set this option to enable an initial connection check performed by this 
+      wrapper application.
+      Default: false
     --deactivateRules
       Specify references of rules you want to deactivate during the scan 
       inside the Owasp Zap. If you specifiy multiple rules use comma separated 

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/CommandLineSettings.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/CommandLineSettings.java
@@ -132,6 +132,14 @@ public class CommandLineSettings {
     }
 
     @Parameter(names = {
+            "--connectionCheck" }, description = "Set this option to enable an initial connection check performed by this wrapper application.", required = false)
+    private boolean connectionCheckEnabled;
+
+    public boolean isConnectionCheckEnabled() {
+        return connectionCheckEnabled;
+    }
+
+    @Parameter(names = {
             "--maxNumberOfConnectionRetries" }, description = "Maximum number of times the wrapper tries to reach each URL. Including each URL constructed from the sechub includes.", required = false)
     private int maxNumberOfConnectionRetries = 3;
 

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutor.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutor.java
@@ -25,7 +25,9 @@ public class OwaspZapScanExecutor {
     }
 
     public void execute(OwaspZapScanContext scanContext) throws ZapWrapperRuntimeException {
-        connectionChecker.assertApplicationIsReachable(scanContext);
+        if (scanContext.isConnectionCheckEnabled()) {
+            connectionChecker.assertApplicationIsReachable(scanContext);
+        }
 
         ClientApi clientApi = clientApiFactory.create(scanContext.getServerConfig());
 

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutor.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutor.java
@@ -25,7 +25,7 @@ public class OwaspZapScanExecutor {
     }
 
     public void execute(OwaspZapScanContext scanContext) throws ZapWrapperRuntimeException {
-        if (scanContext.isConnectionCheckEnabled()) {
+        if (scanContext.connectionCheckEnabled()) {
             connectionChecker.assertApplicationIsReachable(scanContext);
         }
 

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContext.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContext.java
@@ -43,6 +43,8 @@ public class OwaspZapScanContext {
     private Set<URL> owaspZapURLsIncludeList = new HashSet<>();
     private Set<URL> owaspZapURLsExcludeList = new HashSet<>();
 
+    private boolean connectionCheckEnabled;
+
     private int maxNumberOfConnectionRetries;
     private int retryWaittimeInMilliseconds;
 
@@ -129,6 +131,10 @@ public class OwaspZapScanContext {
         return owaspZapURLsExcludeList;
     }
 
+    public boolean isConnectionCheckEnabled() {
+        return connectionCheckEnabled;
+    }
+
     public int getMaxNumberOfConnectionRetries() {
         return maxNumberOfConnectionRetries;
     }
@@ -176,6 +182,8 @@ public class OwaspZapScanContext {
         // Using Set here to avoid duplicates
         private Set<URL> owaspZapURLsIncludeList = new HashSet<>();
         private Set<URL> owaspZapURLsExcludeList = new HashSet<>();
+
+        private boolean connectionCheckEnabled;
 
         private int maxNumberOfConnectionRetries;
         private int setRetryWaittimeInMilliseconds;
@@ -262,6 +270,11 @@ public class OwaspZapScanContext {
             return this;
         }
 
+        public OwaspZapBasicScanContextBuilder setConnectionCheckEnabled(boolean connectionCheckEnabled) {
+            this.connectionCheckEnabled = connectionCheckEnabled;
+            return this;
+        }
+
         public OwaspZapBasicScanContextBuilder setMaxNumberOfConnectionRetries(int maxNumberOfConnectionRetries) {
             this.maxNumberOfConnectionRetries = maxNumberOfConnectionRetries;
             return this;
@@ -301,6 +314,8 @@ public class OwaspZapScanContext {
 
             owaspZapBasicScanConfiguration.owaspZapURLsIncludeList.addAll(this.owaspZapURLsIncludeList);
             owaspZapBasicScanConfiguration.owaspZapURLsExcludeList.addAll(this.owaspZapURLsExcludeList);
+
+            owaspZapBasicScanConfiguration.connectionCheckEnabled = this.connectionCheckEnabled;
 
             owaspZapBasicScanConfiguration.maxNumberOfConnectionRetries = this.maxNumberOfConnectionRetries;
             owaspZapBasicScanConfiguration.retryWaittimeInMilliseconds = this.setRetryWaittimeInMilliseconds;

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContext.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContext.java
@@ -131,7 +131,7 @@ public class OwaspZapScanContext {
         return owaspZapURLsExcludeList;
     }
 
-    public boolean isConnectionCheckEnabled() {
+    public boolean connectionCheckEnabled() {
         return connectionCheckEnabled;
     }
 

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContextFactory.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContextFactory.java
@@ -116,6 +116,7 @@ public class OwaspZapScanContextFactory {
 												.setApiDefinitionFile(apiDefinitionFile)
 												.setOwaspZapURLsIncludeSet(includeSet)
 												.setOwaspZapURLsExcludeSet(excludeSet)
+												.setConnectionCheckEnabled(settings.isConnectionCheckEnabled())
 												.setMaxNumberOfConnectionRetries(settings.getMaxNumberOfConnectionRetries())
 												.setRetryWaittimeInMilliseconds(settings.getRetryWaittimeInMilliseconds())
 												.setOwaspZapProductMessageHelper(productMessagehelper)

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/UnauthenticatedScan.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/UnauthenticatedScan.java
@@ -61,10 +61,9 @@ public class UnauthenticatedScan extends AbstractScan {
         // if no URLs to scan where detected by the spider/ajaxSpider before
         if (!atLeastOneURLDetected()) {
             LOG.warn("For {} skipping active scan, since no URLs where detected by spider or ajaxSpider!", scanContext.getContextName());
-            scanContext.getOwaspZapProductMessageHelper()
-                    .writeSingleProductMessage(new SecHubMessage(SecHubMessageType.WARNING,
-                            "Active scan part of the webscan was skipped, because no URLs where detected by crawling mechanisms! "
-                                    + "Please check if the URL you specified or any of the includes are accessible."));
+            scanContext.getOwaspZapProductMessageHelper().writeSingleProductMessage(
+                    new SecHubMessage(SecHubMessageType.WARNING, "Skipped the active scan, because no URLs were detected by the crawler! "
+                            + "Please check if the URL you specified or any of the includes are accessible."));
             return;
         }
         String targetUrlAsString = scanContext.getTargetUrlAsString();

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/UnauthenticatedScan.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/UnauthenticatedScan.java
@@ -61,8 +61,10 @@ public class UnauthenticatedScan extends AbstractScan {
         // if no URLs to scan where detected by the spider/ajaxSpider before
         if (!atLeastOneURLDetected()) {
             LOG.warn("For {} skipping active scan, since no URLs where detected by spider or ajaxSpider!", scanContext.getContextName());
-            scanContext.getOwaspZapProductMessageHelper().writeSingleProductMessage(new SecHubMessage(SecHubMessageType.WARNING,
-                    "Active scan part of the webscan was skipped, because no URLs where detected by crawling mechanisms!"));
+            scanContext.getOwaspZapProductMessageHelper()
+                    .writeSingleProductMessage(new SecHubMessage(SecHubMessageType.WARNING,
+                            "Active scan part of the webscan was skipped, because no URLs where detected by crawling mechanisms! "
+                                    + "Please check if the URL you specified or any of the includes are accessible."));
             return;
         }
         String targetUrlAsString = scanContext.getTargetUrlAsString();

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/auth/AbstractAuthScan.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/auth/AbstractAuthScan.java
@@ -80,8 +80,10 @@ public abstract class AbstractAuthScan extends AbstractScan implements AuthScan 
         // if no URLs to scan where detected by the spider/ajaxSpider before
         if (!atLeastOneURLDetected()) {
             LOG.warn("For {} skipping active scan, since no URLs where detected by spider or ajaxSpider!", scanContext.getContextName());
-            scanContext.getOwaspZapProductMessageHelper().writeSingleProductMessage(new SecHubMessage(SecHubMessageType.WARNING,
-                    "Active scan part of the webscan was skipped, because no URLs where detected by crawling mechanisms!"));
+            scanContext.getOwaspZapProductMessageHelper()
+                    .writeSingleProductMessage(new SecHubMessage(SecHubMessageType.WARNING,
+                            "Active scan part of the webscan was skipped, because no URLs where detected by crawling mechanisms! "
+                                    + "Please check if the URL you specified or any of the includes are accessible."));
             return;
         }
         String url = scanContext.getTargetUrlAsString();

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/auth/AbstractAuthScan.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/scan/auth/AbstractAuthScan.java
@@ -80,10 +80,9 @@ public abstract class AbstractAuthScan extends AbstractScan implements AuthScan 
         // if no URLs to scan where detected by the spider/ajaxSpider before
         if (!atLeastOneURLDetected()) {
             LOG.warn("For {} skipping active scan, since no URLs where detected by spider or ajaxSpider!", scanContext.getContextName());
-            scanContext.getOwaspZapProductMessageHelper()
-                    .writeSingleProductMessage(new SecHubMessage(SecHubMessageType.WARNING,
-                            "Active scan part of the webscan was skipped, because no URLs where detected by crawling mechanisms! "
-                                    + "Please check if the URL you specified or any of the includes are accessible."));
+            scanContext.getOwaspZapProductMessageHelper().writeSingleProductMessage(
+                    new SecHubMessage(SecHubMessageType.WARNING, "Skipped the active scan, because no URLs were detected by the crawler! "
+                            + "Please check if the URL you specified or any of the includes are accessible."));
             return;
         }
         String url = scanContext.getTargetUrlAsString();

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/util/TargetConnectionChecker.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/owaspzapwrapper/util/TargetConnectionChecker.java
@@ -55,7 +55,7 @@ public class TargetConnectionChecker {
     }
 
     boolean isReponseCodeValid(int responseCode) {
-        return responseCode < 400 || responseCode == 401 || responseCode == 403;
+        return responseCode < 500 && responseCode != 404;
     }
 
     private boolean isSiteCurrentlyReachable(OwaspZapScanContext scanContext, URL url, int maxNumberOfConnectionRetries, int retryWaittimeInMilliseconds) {

--- a/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutorTest.java
+++ b/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutorTest.java
@@ -60,6 +60,7 @@ class OwaspZapScanExecutorTest {
         when(scanContext.getOwaspZapURLsIncludeList()).thenReturn(includeList);
         when(scanContext.getMaxNumberOfConnectionRetries()).thenReturn(1);
         when(scanContext.getRetryWaittimeInMilliseconds()).thenReturn(0);
+        when(scanContext.isConnectionCheckEnabled()).thenReturn(false);
 
         OwaspZapScan scan = mock(OwaspZapScan.class);
         when(resolver.resolveScanImplementation(eq(scanContext), any())).thenReturn(scan);
@@ -70,7 +71,7 @@ class OwaspZapScanExecutorTest {
         executorToTest.execute(scanContext);
 
         /* test */
-        verify(connectionChecker).assertApplicationIsReachable(scanContext);
+        verify(connectionChecker, never()).assertApplicationIsReachable(scanContext);
         verify(clientApiFactory).create(scanContext.getServerConfig());
         verify(resolver).resolveScanImplementation(scanContext, clientApi);
         verify(scan).scan();
@@ -93,6 +94,7 @@ class OwaspZapScanExecutorTest {
         when(scanContext.getMaxNumberOfConnectionRetries()).thenReturn(1);
         when(scanContext.getRetryWaittimeInMilliseconds()).thenReturn(0);
         when(scanContext.getOwaspZapProductMessageHelper()).thenReturn(productMessageHelper);
+        when(scanContext.isConnectionCheckEnabled()).thenReturn(true);
         doNothing().when(productMessageHelper).writeSingleProductMessage(any());
 
         OwaspZapScan scan = mock(OwaspZapScan.class);

--- a/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutorTest.java
+++ b/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/cli/OwaspZapScanExecutorTest.java
@@ -60,7 +60,7 @@ class OwaspZapScanExecutorTest {
         when(scanContext.getOwaspZapURLsIncludeList()).thenReturn(includeList);
         when(scanContext.getMaxNumberOfConnectionRetries()).thenReturn(1);
         when(scanContext.getRetryWaittimeInMilliseconds()).thenReturn(0);
-        when(scanContext.isConnectionCheckEnabled()).thenReturn(false);
+        when(scanContext.connectionCheckEnabled()).thenReturn(false);
 
         OwaspZapScan scan = mock(OwaspZapScan.class);
         when(resolver.resolveScanImplementation(eq(scanContext), any())).thenReturn(scan);
@@ -94,7 +94,7 @@ class OwaspZapScanExecutorTest {
         when(scanContext.getMaxNumberOfConnectionRetries()).thenReturn(1);
         when(scanContext.getRetryWaittimeInMilliseconds()).thenReturn(0);
         when(scanContext.getOwaspZapProductMessageHelper()).thenReturn(productMessageHelper);
-        when(scanContext.isConnectionCheckEnabled()).thenReturn(true);
+        when(scanContext.connectionCheckEnabled()).thenReturn(true);
         doNothing().when(productMessageHelper).writeSingleProductMessage(any());
 
         OwaspZapScan scan = mock(OwaspZapScan.class);

--- a/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContextFactoryTest.java
+++ b/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContextFactoryTest.java
@@ -503,7 +503,7 @@ class OwaspZapScanContextFactoryTest {
         OwaspZapScanContext result = factoryToTest.create(settings);
 
         /* test */
-        assertEquals(result.isConnectionCheckEnabled(), enabled);
+        assertEquals(result.connectionCheckEnabled(), enabled);
 
     }
 

--- a/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContextFactoryTest.java
+++ b/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/config/OwaspZapScanContextFactoryTest.java
@@ -491,6 +491,22 @@ class OwaspZapScanContextFactoryTest {
         assertEquals(2, result.getOwaspZapURLsExcludeList().size());
     }
 
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void connection_check_from_settings_is_in_result(boolean enabled) {
+        /* prepare */
+        CommandLineSettings settings = createSettingsMockWithNecessaryParts();
+        when(settings.isConnectionCheckEnabled()).thenReturn(enabled);
+        when(ruleProvider.fetchDeactivatedRuleReferences(any())).thenReturn(new DeactivatedRuleReferences());
+
+        /* execute */
+        OwaspZapScanContext result = factoryToTest.create(settings);
+
+        /* test */
+        assertEquals(result.isConnectionCheckEnabled(), enabled);
+
+    }
+
     private CommandLineSettings createSettingsMockWithNecessaryParts() {
         CommandLineSettings settings = mock(CommandLineSettings.class);
         when(settings.getTargetURL()).thenReturn("https://www.targeturl.com");

--- a/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/util/TargetConnectionCheckerTest.java
+++ b/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/owaspzapwrapper/util/TargetConnectionCheckerTest.java
@@ -4,7 +4,6 @@ package com.mercedesbenz.sechub.owaspzapwrapper.util;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -17,36 +16,15 @@ class TargetConnectionCheckerTest {
         connectionCheckerToTest = new TargetConnectionChecker();
     }
 
-    @Test
-    void repsonse_code_401_accepted() {
-        /* test */
-        // accept 401-unauthorized as target is reachable
-        assertTrue(connectionCheckerToTest.isReponseCodeValid(401));
-    }
-
-    @Test
-    void repsonse_code_403_accepted() {
-        /* test */
-        // accept 403-forbidden as target is reachable
-        assertTrue(connectionCheckerToTest.isReponseCodeValid(403));
-    }
-
     @ParameterizedTest
-    @ValueSource(ints = { 302, 200, })
-    void repsonse_code_less_than_400_accepted(int responseCode) {
+    @ValueSource(ints = { 302, 200, 401, 403, 405 })
+    void allowed_response_code_return_true(int responseCode) {
         /* test */
         assertTrue(connectionCheckerToTest.isReponseCodeValid(responseCode));
     }
 
-    @Test
-    void edge_case_repsonse_code_400_returns_false() {
-        /* test */
-        // edge case is not allowed
-        assertFalse(connectionCheckerToTest.isReponseCodeValid(400));
-    }
-
     @ParameterizedTest
-    @ValueSource(ints = { 404, 500, 501, })
+    @ValueSource(ints = { 404, 500, 501 })
     void not_allowed_response_code_return_false(int responseCode) {
         /* test */
         assertFalse(connectionCheckerToTest.isReponseCodeValid(responseCode));


### PR DESCRIPTION
### This PR:
- made connection check configurable (added ability to turn it on/off with an executor parameter)
- added the parameter to the PDS_OWASPZAP
- extended the user message when the ZAP sites tree is empty after crawling phase. This is important since we will not perform the initial connection check on default in the future.
- improved connection check logic in case it will be used in the future. We only consider http response codes as failure if we are sure something went wrong on the connection attempts (http 404 or 5xx)
- in pds-config.json updated minutesToWaitForProductResult to 600 to be the largest value, larger than on the executors
- closes #2201 