### PR TITLE
Add labels to the SecHub dockerfiles #2233

### DIFF
--- a/sechub-solution/docker/SecHub-Alpine.dockerfile
+++ b/sechub-solution/docker/SecHub-Alpine.dockerfile
@@ -120,6 +120,9 @@ FROM builder-${BUILD_TYPE} as builder
 
 FROM ${BASE_IMAGE} AS sechub
 
+LABEL org.opencontainers.image.source="https://github.com/mercedes-benz/sechub"
+LABEL org.opencontainers.image.title="SecHub Alpine Linux Image"
+LABEL org.opencontainers.image.description="A container for SecHub based on Alpine Linux"
 LABEL maintainer="SecHub FOSS Team"
 
 ARG SECHUB_ARTIFACT_FOLDER

--- a/sechub-solution/docker/SecHub-Debian.dockerfile
+++ b/sechub-solution/docker/SecHub-Debian.dockerfile
@@ -149,6 +149,9 @@ FROM builder-${BUILD_TYPE} as builder
 
 FROM ${BASE_IMAGE} AS sechub
 
+LABEL org.opencontainers.image.source="https://github.com/mercedes-benz/sechub"
+LABEL org.opencontainers.image.title="SecHub Debian Image"
+LABEL org.opencontainers.image.description="A container for SecHub based on Debian"
 LABEL maintainer="SecHub FOSS Team"
 
 ARG SECHUB_ARTIFACT_FOLDER

--- a/sechub-solution/docker/SecHub-Fedora.dockerfile
+++ b/sechub-solution/docker/SecHub-Fedora.dockerfile
@@ -129,6 +129,9 @@ FROM builder-${BUILD_TYPE} as builder
 
 FROM ${BASE_IMAGE} AS sechub
 
+LABEL org.opencontainers.image.source="https://github.com/mercedes-benz/sechub"
+LABEL org.opencontainers.image.title="SecHub Fedora Image"
+LABEL org.opencontainers.image.description="A container for SecHub based on Fedora"
 LABEL maintainer="SecHub FOSS Team"
 
 ARG SECHUB_ARTIFACT_FOLDER

--- a/sechub-solution/docker/SecHub-Rocky.dockerfile
+++ b/sechub-solution/docker/SecHub-Rocky.dockerfile
@@ -150,6 +150,9 @@ FROM builder-${BUILD_TYPE} as builder
 
 FROM ${BASE_IMAGE} AS sechub
 
+LABEL org.opencontainers.image.source="https://github.com/mercedes-benz/sechub"
+LABEL org.opencontainers.image.title="SecHub Rocky Linux Image"
+LABEL org.opencontainers.image.description="A container for SecHub based on Rocky Linux"
 LABEL maintainer="SecHub FOSS Team"
 
 ARG SECHUB_ARTIFACT_FOLDER


### PR DESCRIPTION
- added labels according to the opencontainers/image-spec
- labels added to: Alpine, Debian, Fedora and Rocky images

closes: #2233