### PR TITLE
Changed sesc status to productive

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -343,7 +343,7 @@ PDS-Solutions:
 [[secretscan]]
 ==== secretScan
 
-**Status: Experimental**
+**Status: Productive**
 
 Scans code or artifacts for secrets (API tokens, certificates, passwords).
 


### PR DESCRIPTION
The status of the SecretScanner is not experimental anymore. That's why it needs to be changed to "productive".

Closes #2364 