### PR TITLE
Update supported-source-extensions.txt

### DIFF
--- a/sechub-cli/script/supported-source-extensions.txt
+++ b/sechub-cli/script/supported-source-extensions.txt
@@ -1,6 +1,7 @@
 Apex: .apex .apexp .apxc .component .-meta.xml .object .page .report .tgr .trigger .workflow
 ASP (Active Server Pages): .asp
 ASP: .ascx .aspx
+Azure: .bicep
 C/C++: .ac .am .c .c++ .cc .cmake .cpp .cxx .ec .h .h++ .hh .hpp .hxx .pro
 C#, VB.NET, Visual Basic, VB Script: .asax .bas .cls .cs .cshtml .csproj .ctl .dsr .frm .master .sln .vb .vbp .vbs .xaml
 Certificates for secrets scans:	.crt, .cer, .csr, .der, .pem, .pfx, .p12, .p7b, .p7c, .CRT, .CER, .CSR, .DER, .PEM, .PFX, .P12, .P7B, .P7C


### PR DESCRIPTION
.bicep is used to define ARM templates.

Marking as supported for secHub CLI within the supported-source-extensions.txt file.