### PR TITLE
Release ZAP Wrapper 1.5.0 #2792

### DIFF
--- a/sechub-pds-solutions/owaspzap/docker/Owasp-Zap-Debian.dockerfile
+++ b/sechub-pds-solutions/owaspzap/docker/Owasp-Zap-Debian.dockerfile
@@ -10,10 +10,11 @@ LABEL org.opencontainers.image.description="A container which combines OWASP ZAP
 LABEL maintainer="SecHub FOSS Team"
 
 # Build args
+# ZAP (Zed Attack Proxy) version. See https://github.com/zaproxy/zaproxy
 ARG OWASPZAP_VERSION="2.14.0"
 ARG OWASPZAP_SHA256SUM="219d7f25bbe25247713805ab02cc12279898c870743c1aae3c2b0b1882191960"
 
-ARG OWASPZAP_WRAPPER_VERSION="1.4.0"
+ARG OWASPZAP_WRAPPER_VERSION="1.5.0"
 
 # OWASP ZAP host and port
 ENV ZAP_HOST="127.0.0.1"

--- a/sechub-pds-solutions/owaspzap/env
+++ b/sechub-pds-solutions/owaspzap/env
@@ -4,7 +4,7 @@
 BASE_IMAGE="ghcr.io/mercedes-benz/sechub/pds-base"
 
 # See: https://github.com/mercedes-benz/sechub/releases/
-OWASPZAP_WRAPPER_VERSION="1.4.0"
+OWASPZAP_WRAPPER_VERSION="1.5.0"
 # See: https://github.com/zaproxy/zaproxy/releases/latest
 OWASPZAP_VERSION="2.14.0"
 OWASPZAP_SHA256SUM="219d7f25bbe25247713805ab02cc12279898c870743c1aae3c2b0b1882191960"


### PR DESCRIPTION
- updated ZAP wrapper version in configs
- closes #2792 