### PR TITLE
Proper docs versioning in build + release job  #2798

### DIFF
--- a/.github/workflows/release-client-server-pds.yml
+++ b/.github/workflows/release-client-server-pds.yml
@@ -69,6 +69,8 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: master
+          fetch-tags: true
+          fetch-depth: 0
       # Create temporary local tags, so we build documentation for this tag...
       # The final tag on git server side will be done by the release when the draft is saved as "real" release
       # automatically.

--- a/buildSrc/src/main/groovy/VersionData.groovy
+++ b/buildSrc/src/main/groovy/VersionData.groovy
@@ -34,13 +34,14 @@ class VersionData{
 
     public class VersionInfo{
 
-        String fullVersion
-        String shortVersion
         String id
         String text
+        String fullVersion
+        String shortVersion
+        String shortVersionForDocs
 
         public String describe(){
-            return text.padLeft(17)+": "+shortVersion+" ("+fullVersion+")"
+            return text.padLeft(17)+": "+shortVersion+" ("+fullVersion+") docs: "+shortVersionForDocs
         }
 
     }
@@ -49,14 +50,15 @@ class VersionData{
 
         VersionInfo info = new VersionInfo()
 
-        info.id=id;
-        info.text=text;
-        info.fullVersion="undefined-long-"+id+"version"
-        info.shortVersion="undefined-"+id+"version"
+        info.id = id;
+        info.text = text;
+        info.fullVersion = "undefined-long-"+id+"version"
+        info.shortVersion = "undefined-"+id+"version"
+        info.shortVersionForDocs = info.shortVersion
         map.put(id, info)
     }
 
-    public VersionInfo defineVersion(String versionType, String fullVersion){
+    public VersionInfo defineVersion(String versionType, String fullVersion, String shortVersionForDocs){
 
         VersionInfo info = map.get(versionType.toLowerCase());
         if (info==null){
@@ -64,7 +66,8 @@ class VersionData{
         }
         inspectReleaseVersion(versionType, fullVersion);
         info.shortVersion = simplifiedVersion(fullVersion);
-        info.fullVersion= fullVersion
+        info.fullVersion = fullVersion
+        info.shortVersionForDocs = shortVersionForDocs
 
         return info;
     }
@@ -73,40 +76,49 @@ class VersionData{
      * Convenience methods: return short version
      */
 
-    public String getLibrariesVersion(){
-        return map.get(ID_LIBRARIES).getShortVersion()
-    }
-
-    public String getServerVersion(){
-        return map.get(ID_SERVER).getShortVersion()
+    public String getCheckmarxWrapperVersion(){
+        return map.get(ID_WRAPPER_CHECKMARX).getShortVersion()
     }
 
     public String getClientVersion(){
         return map.get(ID_CLIENT).getShortVersion()
     }
+    public String getClientDocsVersion(){
+        return map.get(ID_CLIENT).getShortVersionForDocs()
+    }
 
-    public String getCheckmarxWrapperVersion(){
-        return map.get(ID_WRAPPER_CHECKMARX).getShortVersion()
+    public String getLibrariesVersion(){
+        return map.get(ID_LIBRARIES).getShortVersion()
     }
 
     public String getOwaspzapWrapperVersion(){
         return map.get(ID_WRAPPER_OWASPZAP).getShortVersion()
     }
 
-    public String getXrayWrapperVersion(){
-        return map.get(ID_WRAPPER_XRAY).getShortVersion()
-    }
-
     public String getPdsVersion(){
         return map.get(ID_PDS).getShortVersion()
+    }
+    public String getPdsDocsVersion(){
+        return map.get(ID_PDS).getShortVersionForDocs()
     }
 
     public String getPdsToolsVersion(){
         return map.get(ID_PDS_TOOLS).getShortVersion()
     }
 
+    public String getServerVersion(){
+        return map.get(ID_SERVER).getShortVersion()
+    }
+    public String getServerDocsVersion(){
+        return map.get(ID_SERVER).getShortVersionForDocs()
+    }
+
     public String getWebsiteVersion(){
         return map.get(ID_WEBSITE).getShortVersion()
+    }
+
+    public String getXrayWrapperVersion(){
+        return map.get(ID_WRAPPER_XRAY).getShortVersion()
     }
 
     public String getDebugInfo(){

--- a/gradle/build-versioning.gradle
+++ b/gradle/build-versioning.gradle
@@ -67,16 +67,7 @@ def buildVersionFiles(){
     // - Client
     // ------------------------
 
-    // write version code for go client
-    String clientGoVersionTemplate = new File('./sechub-cli/src/mercedes-benz.com/sechub/cli/version.go.template').getText('UTF-8')
-
-    def clientVersionInfo = versionData.defineVersion("Client",buildVersionString(clientVersionCommitTag, hasChanged,buildNumber))
-
-    String clientGoVersionCode = clientGoVersionTemplate.replaceAll("__version__",clientVersionInfo.getFullVersion())
-    def clientVersionFile = new File('./sechub-cli/src/mercedes-benz.com/sechub/cli/version.go')
-    clientVersionFile.write(clientGoVersionCode)
-
-    /* Latest tagged client version as asciidoc file (#2285) */
+    // Get latest tagged client version
     def latestClientTagCmd = [
       'sh',
       '-c',
@@ -85,20 +76,29 @@ def buildVersionFiles(){
     def latestClientTag = latestClientTagCmd.execute().text.trim()
     def latestClientVersion = latestClientTag - 'v'
     latestClientVersion = latestClientVersion - "-client"
+
+    def clientVersionInfo = versionData.defineVersion("Client",buildVersionString(clientVersionCommitTag, hasChanged,buildNumber),latestClientVersion)
+
+    // write version code for go client
+    String clientGoVersionTemplate = new File('./sechub-cli/src/mercedes-benz.com/sechub/cli/version.go.template').getText('UTF-8')
+    String clientGoVersionCode = clientGoVersionTemplate.replaceAll("__version__",clientVersionInfo.getFullVersion())
+    def clientVersionFile = new File('./sechub-cli/src/mercedes-benz.com/sechub/cli/version.go')
+    clientVersionFile.write(clientGoVersionCode)
+
+    // Latest tagged client version as asciidoc file (#2285)
+    def latestClientVersionText = latestClientVersion
     // Mark as modified when built after release
     if (latestClientVersion != clientVersionInfo.getShortVersion()) {
-      latestClientVersion = latestClientVersion + " modified (commit " + currentGitCommit + ")"
+      latestClientVersionText = latestClientVersion + " modified (commit " + currentGitCommit + ")"
     }
     def clientVersionAsciiDocFile = new File('./sechub-doc/src/docs/asciidoc/documents/gen/client-version.adoc')
-    clientVersionAsciiDocFile.write("// SPDX-License-Identifier: MIT\n:revnumber: Client "+latestClientVersion+"\n:longrevnumber: Client "+latestClientVersion+" - Build date: "+docsTimeStamp+"\n")
+    clientVersionAsciiDocFile.write("// SPDX-License-Identifier: MIT\n:revnumber: Client "+latestClientVersionText+"\n:longrevnumber: Client "+latestClientVersionText+" - Build date: "+docsTimeStamp+"\n")
 
     // ------------------------
     // - Server
     // ------------------------
 
-    def serverVersionInfo =  versionData.defineVersion("Server",buildVersionString(serverVersionCommitTag, hasChanged,buildNumber))
-
-    /* Latest tagged server version as asciidoc file (#2285) */
+    // Get latest tagged server version
     def latestServerTagCmd = [
       'sh',
       '-c',
@@ -107,18 +107,21 @@ def buildVersionFiles(){
     def latestServerTag = latestServerTagCmd.execute().text.trim()
     def latestServerVersion = latestServerTag - 'v'
     latestServerVersion = latestServerVersion - "-server"
+
+    def serverVersionInfo =  versionData.defineVersion("Server",buildVersionString(serverVersionCommitTag, hasChanged,buildNumber),latestServerVersion)
+
+    // Latest tagged server version as asciidoc file (#2285)
+    def latestServerVersionText = latestServerVersion
     // Mark as modified when built after release
     if (latestServerVersion != serverVersionInfo.getShortVersion()) {
-      latestServerVersion = latestServerVersion + " modified (commit " + currentGitCommit + ")"
+      latestServerVersionText = latestServerVersion + " modified (commit " + currentGitCommit + ")"
     }
     def serverVersionAsciiDocFile = new File('./sechub-doc/src/docs/asciidoc/documents/gen/server-version.adoc')
-    serverVersionAsciiDocFile.write("// SPDX-License-Identifier: MIT\n:revnumber: Server "+latestServerVersion+"\n:longrevnumber: Server "+latestServerVersion+" - Build date: "+docsTimeStamp+"\n")
+    serverVersionAsciiDocFile.write("// SPDX-License-Identifier: MIT\n:revnumber: Server "+latestServerVersionText+"\n:longrevnumber: Server "+latestServerVersionText+" - Build date: "+docsTimeStamp+"\n")
 
     // ------------------------
     // - PDS
     // ------------------------
-
-    def pdsVersionInfo = versionData.defineVersion("PDS",buildVersionString(pdsVersionCommitTag, hasChanged,buildNumber))
 
     /* Latest tagged pds version as asciidoc file (#2285) */
     def latestPDSTagCmd = [
@@ -129,37 +132,42 @@ def buildVersionFiles(){
     def latestPDSTag = latestPDSTagCmd.execute().text.trim()
     def latestPDSVersion = latestPDSTag - 'v'
     latestPDSVersion = latestPDSVersion - "-pds"
+
+    def pdsVersionInfo = versionData.defineVersion("PDS",buildVersionString(pdsVersionCommitTag, hasChanged,buildNumber),latestPDSVersion)
+
+    // Latest tagged pds version as asciidoc file (#2285)
+    def latestPDSVersionText = latestPDSVersion
     // Mark as modified when built after release
     if (latestPDSVersion != pdsVersionInfo.getShortVersion()) {
-      latestPDSVersion = latestPDSVersion + " modified (commit " + currentGitCommit + ")"
+      latestPDSVersionText = latestPDSVersion + " modified (commit " + currentGitCommit + ")"
     }
     def pdsVersionAsciiDocFile = new File('./sechub-doc/src/docs/asciidoc/documents/gen/pds-version.adoc')
-    pdsVersionAsciiDocFile.write("// SPDX-License-Identifier: MIT\n:revnumber: PDS "+latestPDSVersion+"\n:longrevnumber: PDS "+latestPDSVersion+" - Build date: "+docsTimeStamp+"\n")
+    pdsVersionAsciiDocFile.write("// SPDX-License-Identifier: MIT\n:revnumber: PDS "+latestPDSVersionText+"\n:longrevnumber: PDS "+latestPDSVersionText+" - Build date: "+docsTimeStamp+"\n")
 
     // ------------------------
     // - PDS tools
     // ------------------------
-    def pdsToolsVersionInfo = versionData.defineVersion("PDS-Tools",buildVersionString(pdsToolsVersionCommitTag, hasChanged,buildNumber))
+    def pdsToolsVersionInfo = versionData.defineVersion("PDS-Tools",buildVersionString(pdsToolsVersionCommitTag, hasChanged,buildNumber),pdsToolsVersionCommitTag)
 
     // ------------------------
     // - Libraries
     // ------------------------
-    def librariesVersionInfo =  versionData.defineVersion("Libraries",buildVersionString(librariesVersionCommitTag, hasChanged,buildNumber))
+    def librariesVersionInfo =  versionData.defineVersion("Libraries",buildVersionString(librariesVersionCommitTag, hasChanged,buildNumber),librariesVersionCommitTag)
 
     // ------------------------
     // - Checkmarx wrapper
     // ------------------------
-    def checkmarxWrapperVersionInfo = versionData.defineVersion("Checkmarx Wrapper",buildVersionString(checkmarxWrapperVersionCommitTag, hasChanged, buildNumber))
+    def checkmarxWrapperVersionInfo = versionData.defineVersion("Checkmarx Wrapper",buildVersionString(checkmarxWrapperVersionCommitTag, hasChanged, buildNumber),checkmarxWrapperVersionCommitTag)
 
     // ------------------------
     // - OWASP-ZAP wrapper
     // ------------------------
-    def owaspzapWrapperVersionInfo = versionData.defineVersion("OWASP-ZAP Wrapper",buildVersionString(owaspzapWrapperVersionCommitTag, hasChanged, buildNumber))
+    def owaspzapWrapperVersionInfo = versionData.defineVersion("OWASP-ZAP Wrapper",buildVersionString(owaspzapWrapperVersionCommitTag, hasChanged, buildNumber),owaspzapWrapperVersionCommitTag)
 
     // ------------------------
     // - XRAY wrapper
     // ------------------------
-    def xrayWrapperVersionInfo = versionData.defineVersion("XRAY Wrapper",buildVersionString(xrayWrapperVersionCommitTag, hasChanged, buildNumber))
+    def xrayWrapperVersionInfo = versionData.defineVersion("XRAY Wrapper",buildVersionString(xrayWrapperVersionCommitTag, hasChanged, buildNumber),xrayWrapperVersionCommitTag)
 
 
     def stop = new Date()

--- a/sechub-doc/build.gradle
+++ b/sechub-doc/build.gradle
@@ -73,9 +73,9 @@ def asciidocBuildDir="$buildDir/docs/asciidoc";
 def imagesBuildDir="$buildDir/docs/asciidoc/images";
 def finalHTMLDir = "$buildDir/docs/final-html"
 
-def clientVersion = versionData.getClientVersion()
-def pdsVersion = versionData.getPdsVersion()
-def serverVersion = versionData.getServerVersion()
+def clientVersion = versionData.getClientDocsVersion()
+def pdsVersion = versionData.getPdsDocsVersion()
+def serverVersion = versionData.getServerDocsVersion()
 
 task dropOldGeneratedAsciidoc(dependsOn: 'test'){
     doFirst {


### PR DESCRIPTION
- Actions workflow now fetches git tag history so latest versions can be obtained for documentation versioning
- Extended the `VersionData` Groovy class so the versions for docs can also be stored
- Added the same to the Gradle files
- Tested successfully with `./gradlew documentation-with-pages`
- closes #2798 