### PR TITLE
Fix ZAP configuration order #2811

### DIFF
--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/zapwrapper/cli/ZapWrapperExitCode.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/zapwrapper/cli/ZapWrapperExitCode.java
@@ -27,6 +27,8 @@ public enum ZapWrapperExitCode {
 
     INVALID_INCLUDE_OR_EXCLUDE_URLS(9),
 
+    CLIENT_CERTIFICATE_CONFIG_INVALID(10),
+
     ;
 
     private int exitCode;

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/zapwrapper/scan/ZapScanner.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/zapwrapper/scan/ZapScanner.java
@@ -92,9 +92,9 @@ public class ZapScanner implements ZapScan {
             addReplacerRulesForHeaders();
 
             /* ZAP setup with access to target */
+            importClientCertificate();
             addIncludedAndExcludedUrlsToContext();
             loadApiDefinitions(zapContextId);
-            importClientCertificate();
 
             /* ZAP scan */
             executeScan(zapContextId);
@@ -280,15 +280,23 @@ public class ZapScanner implements ZapScan {
             LOG.info("For scan {}: No client certificate configuration was found!", scanContext.getContextName());
             return;
         }
+        // Should never happen at this point, only if the client certificate file was
+        // not extracted correctly
+        if (!scanContext.getClientCertificateFile().exists()) {
+            throw new ZapWrapperRuntimeException("For scan " + scanContext.getContextName()
+                    + ": A client certificate section was configured inside the sechub configuration, but the client certificate file was not found on the filesystem inside the extracted sources!",
+                    ZapWrapperExitCode.CLIENT_CERTIFICATE_CONFIG_INVALID);
+        }
 
         ClientCertificateConfiguration clientCertificateConfig = optionalClientCertConfig.get();
-        File clientCertififacteFile = scanContext.getClientCertificateFile();
+        File clientCertificateFile = scanContext.getClientCertificateFile();
 
         String password = null;
         if (clientCertificateConfig.getPassword() != null) {
             password = new String(clientCertificateConfig.getPassword());
         }
-        clientApiFacade.importPkcs12ClientCertificate(clientCertififacteFile.getAbsolutePath(), password);
+        LOG.info("For scan {}: Loading client certificate file: {}", scanContext.getContextName(), clientCertificateFile.getAbsolutePath());
+        clientApiFacade.importPkcs12ClientCertificate(clientCertificateFile.getAbsolutePath(), password);
         clientApiFacade.enableClientCertificate();
     }
 

--- a/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/zapwrapper/scan/ZapScanner.java
+++ b/sechub-wrapper-owasp-zap/src/main/java/com/mercedesbenz/sechub/zapwrapper/scan/ZapScanner.java
@@ -92,6 +92,9 @@ public class ZapScanner implements ZapScan {
             addReplacerRulesForHeaders();
 
             /* ZAP setup with access to target */
+            // The order of the following method calls is important. We want to load the
+            // client certificate first, because it could be needed to access the included
+            // URLs or the URLs from the API definitions.
             importClientCertificate();
             addIncludedAndExcludedUrlsToContext();
             loadApiDefinitions(zapContextId);

--- a/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/zapwrapper/scan/ZapScannerTest.java
+++ b/sechub-wrapper-owasp-zap/src/test/java/com/mercedesbenz/sechub/zapwrapper/scan/ZapScannerTest.java
@@ -401,10 +401,12 @@ class ZapScannerTest {
 
         SecHubWebScanConfiguration sechubWebScanConfig = SecHubScanConfiguration.createFromJSON(jsonWithCertPassword).getWebScan().get();
 
-        File clientCertificateFile = new File("backend-cert.p12");
+        File clientCertificateFile = mock(File.class);
 
         when(scanContext.getClientCertificateFile()).thenReturn(clientCertificateFile);
         when(scanContext.getSecHubWebScanConfiguration()).thenReturn(sechubWebScanConfig);
+
+        when(clientCertificateFile.exists()).thenReturn(true);
 
         ApiResponse response = mock(ApiResponse.class);
         when(clientApiFacade.importPkcs12ClientCertificate(any(), any())).thenReturn(response);
@@ -434,10 +436,11 @@ class ZapScannerTest {
 
         SecHubWebScanConfiguration sechubWebScanConfig = SecHubScanConfiguration.createFromJSON(jsonWithoutCertPassword).getWebScan().get();
 
-        File clientCertificateFile = new File("backend-cert.p12");
+        File clientCertificateFile = mock(File.class);
 
         when(scanContext.getClientCertificateFile()).thenReturn(clientCertificateFile);
         when(scanContext.getSecHubWebScanConfiguration()).thenReturn(sechubWebScanConfig);
+        when(clientCertificateFile.exists()).thenReturn(true);
 
         ApiResponse response = mock(ApiResponse.class);
         when(clientApiFacade.importPkcs12ClientCertificate(any(), any())).thenReturn(response);


### PR DESCRIPTION
- closes #2811 
- fix order to load client certificate before openApi definitions
- improve error handling if the client certificate file was not extracted correctly
- update test cases to match improved error handling