### PR TITLE
Updated the mail body for token resets.

### DIFF
--- a/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/user/NewApiTokenRequestedUserNotificationService.java
+++ b/sechub-notification/src/main/java/com/mercedesbenz/sechub/domain/notification/user/NewApiTokenRequestedUserNotificationService.java
@@ -32,8 +32,8 @@ public class NewApiTokenRequestedUserNotificationService {
         String tokenExpireDateTime = serviceHelper.getApiTokenExpireDate();
 
         StringBuilder emailContent = new StringBuilder();
-        emailContent.append("You requested a new API token. The token was created for you and expires at ");
-        emailContent.append(tokenExpireDateTime + ".\n");
+        emailContent.append("You requested a new API token. The link to retrieve it expires at ");
+        emailContent.append(tokenExpireDateTime + " and can only be used once. Any already existing tokens become invalid.\n");
         emailContent.append("Please use the following link to get the token:\n");
         /*
          * important link must be at last line for integration testing. if changes here


### PR DESCRIPTION
I updated the text of the token reset mail so it should be more clear that the link and not the token expires after 24h, that it can only be used once and that any already existing tokens will be invalid after it.

- Closes #2825 