### PR TITLE
chore(action): bind debug input to action debug

### DIFF
--- a/github-actions/scan/action.yml
+++ b/github-actions/scan/action.yml
@@ -36,7 +36,7 @@ inputs:
   debug:
     description: 'SecHub debug output on/off'
     required: false
-    default: false
+    default: ${{ runner.debug == 1 }}
   fail-job-with-findings:
     description: 'job will be marked as failed if sechub finds something'
     required: true


### PR DESCRIPTION
## description

When an action will be executed in debug mode (e.g. via GitHub UI) the secret `ACTIONS_STEP_DEBUG` will be set to true (empty if not enabled). This typically will allow to detect if a run is in debug mode. Because a GitHub action can not automatically read secrets the `runner.debug` variable needs to be used to determine if debug mode is enabled.

When using this as default for the debug input of the action the debug will automatically be forwarded to SecHub.

Overwriting is always possible for the endusers because it is only the default setting of this action.

This change was already tested within GHE.

## useful links

- [Enabling debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging)
- [runner context](https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context)

## limitation

The only problem here is that instead of a not existing `steps.debug` variable the `runner.debug` variable is used.
For debugging steps the usage of the steps context would be better here - but because this context does not offer a debug property we are using the runners property here.
Because when the debug is enabled via UI (I guess this is the most common approach) it will trigger the debug mode for this action as well (...but via the runner).

## _re-run (failed) jobs_ popup

![image](https://github.com/mercedes-benz/sechub/assets/16336640/0534b0a7-e845-4f48-b13f-b39926febf3d)

## additonal information

Because the `runner.debug` returns a `1` a expression is used to make a boolean out of it.

<hr />

<sub>Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))</sub>