### PR TITLE
Rename PDSSecretScanConfigImpl's PDSLicenseScanConfigBuilder static class to PDSSecretScanConfigBuilder 

### DIFF
--- a/sechub-adapter-pds/src/main/java/com/mercedesbenz/sechub/adapter/pds/PDSSecretScanConfigImpl.java
+++ b/sechub-adapter-pds/src/main/java/com/mercedesbenz/sechub/adapter/pds/PDSSecretScanConfigImpl.java
@@ -16,11 +16,11 @@ public class PDSSecretScanConfigImpl extends AbstractCodeScanAdapterConfig imple
         return configData;
     }
 
-    public static PDSLicenseScanConfigBuilder builder() {
-        return new PDSLicenseScanConfigBuilder();
+    public static PDSSecretScanConfigBuilder builder() {
+        return new PDSSecretScanConfigBuilder();
     }
 
-    public static class PDSLicenseScanConfigBuilder extends AbstractCodeScanAdapterConfigBuilder<PDSLicenseScanConfigBuilder, PDSSecretScanConfigImpl>
+    public static class PDSSecretScanConfigBuilder extends AbstractCodeScanAdapterConfigBuilder<PDSSecretScanConfigBuilder, PDSSecretScanConfigImpl>
             implements PDSAdapterConfigBuilder {
         private PDSAdapterDataConfigurator configurator = new PDSAdapterDataConfigurator();
 


### PR DESCRIPTION
Rename PDSSecretScanConfigImpl's PDSLicenseScanConfigBuilder static class to PDSSecretScanConfigBuilder #2933
- closes #2933 