### PR TITLE
sanitize github actions input strings #3143

### DIFF
--- a/github-actions/scan/__test__/input-helper.test.ts
+++ b/github-actions/scan/__test__/input-helper.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+import {split} from '../src/input-helper';
+
+jest.mock('@actions/core');
+
+describe('split', function () {
+    it('input undefined - returns empty array', function () {
+        /* prepare */
+        const input: any = undefined;
+
+        /* execute */
+        const result = split(input);
+
+        /* test */
+        expect(result).toEqual([]);
+    });
+
+    it('input null - returns empty array', function () {
+        /* prepare */
+        const input: any = null;
+
+        /* execute */
+        const result = split(input);
+
+        /* test */
+        expect(result).toEqual([]);
+    });
+
+    it('input empty - returns empty array', function () {
+        /* prepare */
+        const input: any = '';
+
+        /* execute */
+        const result = split(input);
+
+        /* test */
+        expect(result).toEqual([]);
+    });
+
+    it('input single whitespace - returns empty array', function () {
+        /* prepare */
+        const input: any = ' ';
+
+        /* execute */
+        const result = split(input);
+
+        /* test */
+        expect(result).toEqual([]);
+    });
+
+    it('input single comma - returns empty array', function () {
+        /* prepare */
+        const input: any = ',';
+
+        /* execute */
+        const result = split(input);
+
+        /* test */
+        expect(result).toEqual([]);
+    });
+
+    it('input single value - returns array with single value', function () {
+        /* prepare */
+        const input: any = 'a';
+
+        /* execute */
+        const result = split(input);
+
+        /* test */
+        expect(result).toEqual(['a']);
+    });
+
+    it('input multiple comma separated values - returns array with multiple values', function () {
+        /* prepare */
+        const input: any = 'a, b, c, d, e, f, g';
+
+        /* execute */
+        const result = split(input);
+
+        /* test */
+        expect(result).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    });
+});

--- a/github-actions/scan/__test__/report-format.test.ts
+++ b/github-actions/scan/__test__/report-format.test.ts
@@ -27,6 +27,18 @@ describe('getValidFormatsFromInput', function() {
         expect(validFormats).toEqual(expectedFormats);
     });
 
+    it('correctly returns report formats for json, html', function () {
+        /* prepare */
+        const inputFormats = 'json, html';
+        const expectedFormats = ['json', 'html'];
+
+        /* execute */
+        const validFormats = getValidFormatsFromInput(inputFormats);
+
+        /* test */
+        expect(validFormats).toEqual(expectedFormats);
+    });
+
     it('correctly filter invalid report formats', function () {
         /* prepare */
         const inputFormats = 'json,xml,yml';

--- a/github-actions/scan/src/input-helper.ts
+++ b/github-actions/scan/src/input-helper.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+const COMMA = ',';
+
+/**
+ * Splits an input string by comma and sanitizes the result by removing leading and trailing whitespaces.
+ * Result will contain non-empty strings only.
+ *
+ * @returns array of comma separated strings
+ */
+export function split(input: string): string[] {
+    if (!input) return [];
+
+    return input
+        .split(COMMA)
+        .map(item => item.trim())
+        .filter(item => item.length > 0);
+}

--- a/github-actions/scan/src/launcher.ts
+++ b/github-actions/scan/src/launcher.ts
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: MIT
 
 import * as core from '@actions/core';
-import { failAction } from './action-helper';
-import { downloadClientRelease } from './client-download';
-import { SecHubConfigurationModelBuilderData } from './configuration-builder';
-import { ContentType, ScanType } from './configuration-model';
-import { initEnvironmentVariables } from './environment';
-import { logExitCode } from './exitcode';
-import { getFiles, getWorkspaceDir } from './fs-helper';
-import { GitHubInputData, INPUT_DATA_DEFAULTS, resolveGitHubInputData } from './github-input';
-import { initReportFormats, initSecHubJson } from './init-scan';
-import { collectReportData, reportOutputs, uploadArtifact } from './post-scan';
+import {failAction} from './action-helper';
+import {downloadClientRelease} from './client-download';
+import {SecHubConfigurationModelBuilderData} from './configuration-builder';
+import {ContentType, ScanType} from './configuration-model';
+import {initEnvironmentVariables} from './environment';
+import {logExitCode} from './exitcode';
+import {getFiles, getWorkspaceDir} from './fs-helper';
+import {GitHubInputData, INPUT_DATA_DEFAULTS, resolveGitHubInputData} from './github-input';
+import {initReportFormats, initSecHubJson} from './init-scan';
+import {collectReportData, reportOutputs, uploadArtifact} from './post-scan';
 import * as projectNameResolver from './projectname-resolver';
-import { scan } from './sechub-cli';
+import {scan} from './sechub-cli';
+import {split} from "./input-helper";
 
 /**
  * Starts the launch process
@@ -134,10 +135,10 @@ function createContext(): LaunchContext {
 function createSafeBuilderData(gitHubInputData: GitHubInputData) {
     const builderData = new SecHubConfigurationModelBuilderData();
 
-    builderData.includeFolders = gitHubInputData.includeFolders?.split(',');
-    builderData.excludeFolders = gitHubInputData.excludeFolders?.split(',');
+    builderData.includeFolders = split(gitHubInputData.includeFolders);
+    builderData.excludeFolders = split(gitHubInputData.excludeFolders);
 
-    builderData.scanTypes = ScanType.ensureAccepted(gitHubInputData.scanTypes?.split(','));
+    builderData.scanTypes = ScanType.ensureAccepted(split(gitHubInputData.scanTypes));
     builderData.contentType = ContentType.ensureAccepted(gitHubInputData.contentType);
     return builderData;
 }
@@ -178,11 +179,9 @@ async function postScan(context: LaunchContext): Promise<void> {
     await uploadArtifact(context, 'sechub scan-report', getFiles(`${context.workspaceFolder}/sechub_report_*.*`));
 
     core.debug(`postScan(2): context.lastExitCode=${context.lastClientExitCode}, context.trafficLight='${context.trafficLight}', context.inputData.failJobOnFindings='${context.inputData.failJobOnFindings}'`);
-    if (context.trafficLight =='RED' || context.trafficLight == 'OFF') {
-        if (context.inputData.failJobOnFindings == 'true' || context.inputData.failJobOnFindings == '' ) {
+    if (context.trafficLight == 'RED' || context.trafficLight == 'OFF') {
+        if (context.inputData.failJobOnFindings == 'true' || context.inputData.failJobOnFindings == '') {
             failAction(1);
         }
     }
 }
-
-

--- a/github-actions/scan/src/report-formats.ts
+++ b/github-actions/scan/src/report-formats.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+import {split} from "./input-helper";
+
 export const availableFormats = ['json', 'html', 'spdx-json'];
 
 /**
@@ -7,7 +9,7 @@ export const availableFormats = ['json', 'html', 'spdx-json'];
  * @param inputFormats Formats from the action input
  */
 export function getValidFormatsFromInput(inputFormats: string): string[] {
-    const formats = inputFormats.split(',');
+    const formats = split(inputFormats);
     if (formats.length === 0) { return []; }
     return formats.filter((item) => availableFormats.includes(item));
 }


### PR DESCRIPTION
closes #3143

note: The `createSafeBuilderData` method of the `launcher.ts` component is a candidate for testing, but since it's not exposed as a public function it's not accessible from outside. Testing it through the `launch` method call would be complex for the sake of this pull request. 
We might consider to refactor the `launcher.ts` component in the future.
