### PR TITLE
Enable pull request hook in GitHub action workflow #3357

### DIFF
--- a/.github/workflows/github-action-scan.yml
+++ b/.github/workflows/github-action-scan.yml
@@ -10,16 +10,12 @@ on:
     branches:
       - 'main'
       - 'develop'
-    # This specifies the source branches to exclude from triggering the workflow
-    # We don't want to trigger this workflow for feature increments
-    branches-ignore:
-      - 'feature_*'
-      - 'feature-*'
   # enable manual triggering of workflow
   workflow_dispatch:
 
 jobs:
   build-scan:
+    if: "startsWith(github.head_ref, 'gha_') || startsWith(github.head_ref, 'gha-')"
     runs-on: ubuntu-latest
     # Let's set the scan action folder as the working directory for all "run" steps:
     

--- a/.github/workflows/github-action-scan.yml
+++ b/.github/workflows/github-action-scan.yml
@@ -16,8 +16,8 @@ on:
 
 jobs:
   build-scan:
-    # This job is only executed if the branch name starts with 'gha_' or 'gha-'
-    if: "startsWith(github.head_ref, 'gha_') || startsWith(github.head_ref, 'gha-')"
+    # This job is only executed if the branch name starts with 'gha-'
+    if: "startsWith(github.head_ref, 'gha-')"
     runs-on: ubuntu-latest
     # Let's set the scan action folder as the working directory for all "run" steps:
     

--- a/.github/workflows/github-action-scan.yml
+++ b/.github/workflows/github-action-scan.yml
@@ -4,7 +4,12 @@ name: Build SecHub GHA (scan)
 on:
   push:
     branches:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches:
       - 'gha_*'
+      - 'gha-*'
   # enable manual triggering of workflow
   workflow_dispatch:
 

--- a/.github/workflows/github-action-scan.yml
+++ b/.github/workflows/github-action-scan.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'development'
+      - 'develop'
     # This specifies the source branches to exclude from triggering the workflow
     # We don't want to trigger this workflow for feature increments
     branches-ignore:

--- a/.github/workflows/github-action-scan.yml
+++ b/.github/workflows/github-action-scan.yml
@@ -8,8 +8,13 @@ on:
       - 'develop'
   pull_request:
     branches:
-      - 'gha_*'
-      - 'gha-*'
+      - 'main'
+      - 'development'
+    # This specifies the source branches to exclude from triggering the workflow
+    # We don't want to trigger this workflow for feature increments
+    branches-ignore:
+      - 'feature_*'
+      - 'feature-*'
   # enable manual triggering of workflow
   workflow_dispatch:
 

--- a/.github/workflows/github-action-scan.yml
+++ b/.github/workflows/github-action-scan.yml
@@ -7,6 +7,7 @@ on:
       - 'main'
       - 'develop'
   pull_request:
+    # This workflow will run for all pull requests that target 'main' or 'develop'
     branches:
       - 'main'
       - 'develop'
@@ -15,6 +16,7 @@ on:
 
 jobs:
   build-scan:
+    # This job is only executed if the branch name starts with 'gha_' or 'gha-'
     if: "startsWith(github.head_ref, 'gha_') || startsWith(github.head_ref, 'gha-')"
     runs-on: ubuntu-latest
     # Let's set the scan action folder as the working directory for all "run" steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,12 +3,17 @@ name: Java & Go CI
 
 on:
   push:
-    branches-ignore:
-      # We do NOT build github action development branches here (because no Java or Go code is changed)
-      - 'gha_*'
+    branches:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches:
+      - 'feature_*'
+      - 'feature-*'
       # We ignore everything where tag starts with v* - this is done by release build!
     tags-ignore:
       - v*
+
   # enable manual triggering of workflow
   workflow_dispatch:
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,11 +6,13 @@ on:
     branches:
       - 'main'
       - 'develop'
+    # We ignore everything where tag starts with v* - this is done by release build!
+    tags-ignore:
+      - v*
   pull_request:
     branches:
       - 'feature_*'
       - 'feature-*'
-      # We ignore everything where tag starts with v* - this is done by release build!
     tags-ignore:
       - v*
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,6 +10,7 @@ on:
     tags-ignore:
       - v*
   pull_request:
+    # This workflow will run for all pull requests that target 'main' or 'develop'
     branches:
       - 'main'
       - 'develop'
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build:
+    # This job is only executed if the branch name starts with 'feature_' or 'feature-'
     if: "startsWith(github.head_ref, 'feature_') || startsWith(github.head_ref, 'feature-')"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,11 +13,6 @@ on:
     branches:
       - 'main'
       - 'develop'
-    # This specifies the source branches to exclude from triggering the workflow
-    # We don't want to trigger this workflow for changes on GitHub actions files
-    branches-ignore:
-      - 'gha_*'
-      - 'gha-*'
     tags-ignore:
       - v*
 
@@ -26,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: "startsWith(github.head_ref, 'feature_') || startsWith(github.head_ref, 'feature-')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,8 +22,8 @@ on:
 
 jobs:
   build:
-    # This job is only executed if the branch name starts with 'feature_' or 'feature-'
-    if: "startsWith(github.head_ref, 'feature_') || startsWith(github.head_ref, 'feature-')"
+    # This job is only executed if the branch name starts with or 'feature-'
+    if: "startsWith(github.head_ref, 'feature-')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'development'
+      - 'develop'
     # This specifies the source branches to exclude from triggering the workflow
     # We don't want to trigger this workflow for changes on GitHub actions files
     branches-ignore:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,8 +11,13 @@ on:
       - v*
   pull_request:
     branches:
-      - 'feature_*'
-      - 'feature-*'
+      - 'main'
+      - 'development'
+    # This specifies the source branches to exclude from triggering the workflow
+    # We don't want to trigger this workflow for changes on GitHub actions files
+    branches-ignore:
+      - 'gha_*'
+      - 'gha-*'
     tags-ignore:
       - v*
 


### PR DESCRIPTION
With this GitHub Actions workflows will run for:
- direct pushes to `main` or `develop`
- pull requests that are opened and target `main` or `develop`

Please note that it's not possible to exclude source branches inside the `pull_request` hook. That's why I chose to implement the skip of certain branches inside the job definition.

- closes #3357