### PR TITLE
Feature 3641 make client builds reproducible #3641

### DIFF
--- a/gradle/build-versioning.gradle
+++ b/gradle/build-versioning.gradle
@@ -63,7 +63,7 @@ def buildVersionFiles(){
     def noStagedChanges = stagedChanges.getAllChanges().isEmpty()
     def hasChanged = !noUnstagedChanges || !noStagedChanges
     def buildNumber = getBuildNr()
-    def docsTimeStamp = getLocalBuildNr()
+    def docsTimeStamp = getTimeStamp()
     def currentGitCommit = git.head().abbreviatedId
 
     // ------------------------
@@ -336,8 +336,8 @@ def buildVersionString(commitTag, boolean hasChanged, buildNumber){
         calcversion = calcversion - "-libraries"
         calcversion = calcversion - "-pds-tools"
         calcversion = calcversion - "-pds"
-        calcversion = calcversion - "-server"
         calcversion = calcversion - "-web-server"
+        calcversion = calcversion - "-server"
         calcversion = calcversion - "-checkmarx-wrapper"
         calcversion = calcversion - "-owaspzap-wrapper"
         calcversion = calcversion - "-prepare-wrapper"
@@ -349,20 +349,22 @@ def buildVersionString(commitTag, boolean hasChanged, buildNumber){
     if (hasChanged){
         calcversion = "${calcversion}-dirty"
     }
-    calcversion = "${calcversion}-${buildNumber}"
+    if (buildNumber != "") {
+        calcversion = "${calcversion}-${buildNumber}"
+    }
     return calcversion
 }
 
 def getBuildNr(){
-    if (getServerBuildNr()!=null){
+    if (getServerBuildNr()!=null) {
         return "b"+getServerBuildNr()
-    }else{
+    } else {
         if (project.hasProperty('sechub.build.timestamp')){
             if (project.getProperty('sechub.build.timestamp')=="false"){
                 return "latest"
             }
         }
-        return getLocalBuildNr()
+        return ""
     }
 }
 
@@ -370,8 +372,8 @@ def getServerBuildNr(){
     return System.getenv('BUILD_NUMBER' )
 }
 
-def getLocalBuildNr() {
-    return new Date().format('yyyyMMddHHmmss')
+def getTimeStamp() {
+    return new Date().format("yyyy-MM-dd HH:mm ('UTC'X)")
 }
 
 

--- a/sechub-cli/build_go.sh
+++ b/sechub-cli/build_go.sh
@@ -64,7 +64,8 @@ init_go_modules
 cd "$SRC_PATH/main"
 
 export CGO_ENABLED=0  # This forces statically linked binaries
-GO_LD_FLAGS="-s -w"   # strip (reduce size): disable debug symbol table / disable DWARF generation
+GO_LD_FLAGS="-s -w -buildid=" # strip (reduce size): disable debug symbol table / disable DWARF generation
+GO_COMPILE_FLAGS="-trimpath"  # Aim to make builds reproducible
 
 for platform in "${platforms[@]}" ; do
     platform_split=(${platform//\// })
@@ -82,7 +83,7 @@ for platform in "${platforms[@]}" ; do
     fi
 
     echo "> building $targetSubFolder"
-    go build -ldflags="$GO_LD_FLAGS" -o "$buildDir/$output_name" .
+    go build $GO_COMPILE_FLAGS -ldflags="$GO_LD_FLAGS" -o "$buildDir/$output_name" .
     if [ $? -ne 0 ]; then
         echo 'Go build failed because of an error'
         exit 1


### PR DESCRIPTION
- closes #3641 

Related information: see https://hackernoon.com/building-reproducible-verifiable-binaries-with-golang
--> "There is no built-in way to compile a reproducible binary with Golang."

Anyhow with the applied changes, now the build is reproducible on the same platform (Linux) with the same Go version (go version go1.21.6 linux/amd64) across different machines:
- Developer Laptop running Ubuntu
- local VM running Debian
- two different cloud VMs running Debian (different CPUs)

Also the build is now agnostic of build pathes.
(Builds in different directories produce the same sha256 checksums.)