### PR TITLE
Rename shutdown listener log message on runtime exceptions

### DIFF
--- a/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/shutdown/SpringApplicationShutdownHandler.java
+++ b/sechub-shared-kernel/src/main/java/com/mercedesbenz/sechub/sharedkernel/shutdown/SpringApplicationShutdownHandler.java
@@ -38,7 +38,7 @@ public class SpringApplicationShutdownHandler implements ApplicationShutdownHand
             try {
                 listener.onShutdown();
             } catch (RuntimeException e) {
-                log.error("Notified shutdown listener failed: {}", listener.getClass(), e);
+                log.error("Shutdown: Notified listener {} failed", listener.getClass(), e);
             }
         });
     }


### PR DESCRIPTION
This is a follow up issue from PR #3918 - changed the log error message