### PR TITLE
remove incompatible CachedSingletonsRegistry #4370

### DIFF
--- a/ide-plugins/jetbrains/build.gradle
+++ b/ide-plugins/jetbrains/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 apply plugin: 'org.jetbrains.intellij'
 
 group 'com.mercedesbenz.sechub'
-version '1.0.0'
+version '1.0.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/ide-plugins/jetbrains/src/main/java-intellij/com/mercedesbenz/sechub/plugin/idea/falsepositive/FalsePositivesCacheManager.java
+++ b/ide-plugins/jetbrains/src/main/java-intellij/com/mercedesbenz/sechub/plugin/idea/falsepositive/FalsePositivesCacheManager.java
@@ -3,7 +3,6 @@ package com.mercedesbenz.sechub.plugin.idea.falsepositive;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.openapi.application.CachedSingletonsRegistry;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.mercedesbenz.sechub.api.internal.gen.model.FalsePositiveJobData;
 import com.mercedesbenz.sechub.api.internal.gen.model.FalsePositives;
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -156,7 +154,7 @@ public class FalsePositivesCacheManager {
 
         private static final Map<UUID, FalsePositivesList> runtimeCache = new ConcurrentHashMap<>();
         private static final ObjectMapper mapper = new ObjectMapper();
-        private static final Supplier<PropertiesComponent> persistentCacheSupplier = CachedSingletonsRegistry.lazy(PropertiesComponent::getInstance);
+        private static final PropertiesComponent persistentCache = PropertiesComponent.getInstance();
 
         private void persist(UUID jobUUID) {
             if (!runtimeCache.containsKey(jobUUID)) {
@@ -177,7 +175,7 @@ public class FalsePositivesCacheManager {
                 throw new RuntimeException(errMsg, e);
             }
 
-            persistentCacheSupplier.get().setValue(jobUUID.toString(), json);
+            persistentCache.setValue(jobUUID.toString(), json);
         }
 
         private Optional<FalsePositivesList> getEntry(UUID jobUUID) {
@@ -224,7 +222,7 @@ public class FalsePositivesCacheManager {
          * @return a {@link FalsePositivesList} object
          */
         private FalsePositivesList loadFalsePositives(UUID jobUUID) {
-            String persistentCacheEntries = persistentCacheSupplier.get().getValue(jobUUID.toString());
+            String persistentCacheEntries = persistentCache.getValue(jobUUID.toString());
 
             if (persistentCacheEntries == null || persistentCacheEntries.isEmpty()) {
                 return new FalsePositivesList(new ArrayList<>());
@@ -251,7 +249,7 @@ public class FalsePositivesCacheManager {
         private void clear(UUID jobUUID) {
             requireNonNull(jobUUID, "Parameter 'jobUUID' must not be null");
             runtimeCache.remove(jobUUID);
-            persistentCacheSupplier.get().unsetValue(jobUUID.toString());
+            persistentCache.unsetValue(jobUUID.toString());
         }
     }
 

--- a/ide-plugins/jetbrains/src/main/java-intellij/com/mercedesbenz/sechub/plugin/idea/falsepositive/FalsePositivesCacheManager.java
+++ b/ide-plugins/jetbrains/src/main/java-intellij/com/mercedesbenz/sechub/plugin/idea/falsepositive/FalsePositivesCacheManager.java
@@ -155,7 +155,7 @@ public class FalsePositivesCacheManager {
         private static final Map<UUID, FalsePositivesList> runtimeCache = new ConcurrentHashMap<>();
         private static final ObjectMapper mapper = new ObjectMapper();
 
-        /* IntelliJ Application services must not be accessed in static way */
+        /* IntelliJ Application services must not be assigned to static variable */
         private final PropertiesComponent persistentCache = PropertiesComponent.getInstance();
 
         private void persist(UUID jobUUID) {

--- a/ide-plugins/jetbrains/src/main/java-intellij/com/mercedesbenz/sechub/plugin/idea/falsepositive/FalsePositivesCacheManager.java
+++ b/ide-plugins/jetbrains/src/main/java-intellij/com/mercedesbenz/sechub/plugin/idea/falsepositive/FalsePositivesCacheManager.java
@@ -154,7 +154,9 @@ public class FalsePositivesCacheManager {
 
         private static final Map<UUID, FalsePositivesList> runtimeCache = new ConcurrentHashMap<>();
         private static final ObjectMapper mapper = new ObjectMapper();
-        private static final PropertiesComponent persistentCache = PropertiesComponent.getInstance();
+
+        /* IntelliJ Application services must not be accessed in static way */
+        private final PropertiesComponent persistentCache = PropertiesComponent.getInstance();
 
         private void persist(UUID jobUUID) {
             if (!runtimeCache.containsKey(jobUUID)) {


### PR DESCRIPTION
- closes #4370 

Supplier of type `CachedSingletonsRegistry.lazy(PropertiesComponent::getInstance)` was a workaround to assign the persistent cache to a static variable.

The `CachedSingletonsRegistry` causes trouble in newer versions of IntelliJ.

IntelliJ application services should not be assigned to static variables anyways due to lifecycle bindings. Simply making the `persistentCache` an instance variable solves this issue